### PR TITLE
[numba backend] multi-qubit gate bug fixed

### DIFF
--- a/blueqat/backends/_numba_backend_impl.py
+++ b/blueqat/backends/_numba_backend_impl.py
@@ -76,10 +76,11 @@ def _shifted(lower_mask, idx):
 
 @njit(_QSMask[:](_QBIdx[:]), nogil=True, cache=True)
 def _create_masks(indices):
-    masks = np.empty(len(indices), dtype=_QSMask_dtype)
+    masks = np.empty(len(indices) + 1, dtype=_QSMask_dtype)
     for i, x in enumerate(indices):
         masks[i] = (1 << x) - 1
-    for i in range(len(indices), 0, -1):
+    masks[-1] = ~0
+    for i in range(len(masks), 0, -1):
         masks[i] &= ~masks[i - 1]
     return masks
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -327,6 +327,14 @@ def test_idlequbit_circuit(backend):
     assert is_vec_same(c.run(backend=backend), np.array([0., 0., 0., 1., 0., 0., 0., 0.]))
 
 
+def test_idlequbit_circuit2(backend):
+    '''Refer issues #76 (https://github.com/Blueqat/Blueqat/issues/76)'''
+    c = Circuit(4).x[0].cx[0, 1]
+    result = np.zeros(16)
+    result[3] = 1.0
+    assert is_vec_same(c.run(backend=backend), result)
+
+
 def test_switch_backend1():
     c = Circuit().x[0].h[0]
     assert np.array_equal(c.run(), c.run(backend="numpy"))


### PR DESCRIPTION
Circuit(4).x[0].cx[0,1] returns wrong result.
Related: #78, #76 