### PR TITLE
API:ignore_global option default value changed. (True->False)

### DIFF
--- a/blueqat/backends/_numba_backend_impl.py
+++ b/blueqat/backends/_numba_backend_impl.py
@@ -377,7 +377,7 @@ class NumbaBackend(Backend):
             return
 
     def run(self, gates, n_qubits, *args, **kwargs):
-        def __parse_run_args(shots=None, returns=None, enable_cache=True, ignore_global=True,
+        def __parse_run_args(shots=None, returns=None, enable_cache=True, ignore_global=False,
                              dtype=DEFAULT_DTYPE, **_kwargs):
             if returns is None:
                 if shots is None:

--- a/blueqat/backends/numpy_backend.py
+++ b/blueqat/backends/numpy_backend.py
@@ -85,7 +85,7 @@ class NumPyBackend(Backend):
             return
 
     def run(self, gates, n_qubits, *args, **kwargs):
-        def __parse_run_args(shots=None, returns=None, ignore_global=True, **_kwargs):
+        def __parse_run_args(shots=None, returns=None, ignore_global=False, **_kwargs):
             if returns is None:
                 if shots is None:
                     returns = "statevector"


### PR DESCRIPTION
Change the default value of `ignore_global` option in numpy_backend and numba_backend.
The value changed False to True.