### PR TITLE
Use miniconda for CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,40 @@ executors:
       docker:
           - image: circleci/python:<< parameters.tag >>
 
+    miniconda:
+      parameters:
+        tag:
+          type: string
+      working_directory: ~/repo<< parameters.tag >>
+
 
 commands:
+  install_for_doctest:
+    parameters:
+      tag:
+        type: string
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-<<parameters.tag>>-{{ checksum "requirements.txt" }}
+
+      - run:
+          name: Install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --progress-bar off -U pip setuptools
+            pip install --progress-bar off pytest twine wheel
+            pip install --progress-bar off -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-<<parameters.tag>>-{{ checksum "requirements.txt" }}
+
   install:
     parameters:
       tag:
@@ -25,15 +57,14 @@ commands:
 
       - restore_cache:
           keys:
-          - v1-dependencies-<<parameters.tag>>-{{ checksum "requirements.txt" }}-{{ checksum "optional-requirements.txt" }}
+          - v1-conda-<<parameters.tag>>-{{ checksum "requirements.txt" }}-{{ checksum "optional-requirements.txt" }}
 
       - run:
           name: Install dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install --progress-bar off -U pip setuptools
-            pip install --progress-bar off pytest twine wheel
+            conda create -qy --name py<<parameters.tag>> python=<<parameters.tag>>
+            conda activate py<<parameters.tag>>
+            conda install -qy numpy scipy numba pytest twine wheel setuptools
             pip install --progress-bar off -r requirements.txt
             pip install --progress-bar off -r optional-requirements.txt
 
@@ -43,13 +74,13 @@ commands:
             - run:
                 name: Install qgate
                 command: |
-                  . venv/bin/activate
+                  conda activate py<<parameters.tag>>
                   pip install << parameters.qgate_url >>
 
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "optional-requirements.txt" }}
+            - /opt/conda/envs/py<<parameters.tag>>
+          key: v1-conda-<<parameters.tag>>-{{ checksum "requirements.txt" }}-{{ checksum "optional-requirements.txt" }}
 
 jobs:
   doccheck:
@@ -58,7 +89,7 @@ jobs:
       tag: "3.7.8"
 
     steps:
-      - install:
+      - install_for_doctest:
           tag: "3.7.8"
 
       - run:
@@ -95,7 +126,6 @@ jobs:
 
       - run:
           name: run tests
-          no_output_timeout: 30m
           command: |
             . venv/bin/activate
             python -m pytest tests/ -v --junitxml=test-reports/python/junit.xml <<parameters.test_option>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ commands:
       - run:
           name: Install dependencies
           command: |
+            conda init bash
             conda create -qy --name py<<parameters.tag>> python=<<parameters.tag>>
             conda activate py<<parameters.tag>>
             conda install -qy numpy scipy numba pytest twine wheel setuptools
@@ -129,15 +130,9 @@ jobs:
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
+            conda init bash
+            conda activate py<<parameters.tag>>
             python -m pytest tests/ -v --junitxml=test-reports/python/junit.xml <<parameters.test_option>>
-
-      - run:
-          name: twine check
-          command: |
-            . venv/bin/activate
-            python setup.py build sdist bdist_wheel
-            twine check dist/*
 
       - store_test_results:
           path: test-reports
@@ -158,12 +153,12 @@ workflows:
 
       - test_main:
           name: py3.7-qgate-0.2.2
-          tag: "3.7.8"
+          tag: "3.7.9"
           qgate_url: https://github.com/shinmorino/qgate/raw/gh-pages/packages/0.2/qgate-0.2.2-cp37-cp37m-manylinux1_x86_64.whl
 
       - test_main:
           name: py3.8-qgate-0.2.2
-          tag: "3.8.7"
+          tag: "3.8.8"
           qgate_url: https://github.com/shinmorino/qgate/raw/gh-pages/packages/0.2/qgate-0.2.2-cp38-cp38-manylinux1_x86_64.whl
 
       # py3.9 is pending because some optional-dependencies are still not supported.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ executors:
         tag:
           type: string
       working_directory: ~/repo<< parameters.tag >>
+      docker:
+        - image: continuumio/miniconda3:4.9.2
 
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       parameters:
         tag:
           type: string
-      working_directory: ~/repo<< parameters.tag >>
+      working_directory: ~/miniconda3-<< parameters.tag >>
       docker:
         - image: continuumio/miniconda3:4.9.2
 
@@ -114,7 +114,7 @@ jobs:
         default: ""
 
     executor:
-      name: python
+      name: miniconda
       tag: <<parameters.tag>>
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ commands:
           name: Install dependencies
           command: |
             conda init bash
+            . ~/.bashrc
             conda create -qy --name py<<parameters.tag>> python=<<parameters.tag>>
             conda activate py<<parameters.tag>>
             conda install -qy numpy scipy numba pytest twine wheel setuptools
@@ -77,6 +78,8 @@ commands:
             - run:
                 name: Install qgate
                 command: |
+                  conda init bash
+                  . ~/.bashrc
                   conda activate py<<parameters.tag>>
                   pip install << parameters.qgate_url >>
 
@@ -131,6 +134,7 @@ jobs:
           name: run tests
           command: |
             conda init bash
+            . ~/.bashrc
             conda activate py<<parameters.tag>>
             python -m pytest tests/ -v --junitxml=test-reports/python/junit.xml <<parameters.test_option>>
 


### PR DESCRIPTION
Due to unknown reasons, `numba` on CircleCI official python image is very slow.
So, I use miniconda image for test.