### PR TITLE
ENH: circuitmacro decorator

### DIFF
--- a/blueqat/__init__.py
+++ b/blueqat/__init__.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from .circuit import Circuit, BlueqatGlobalSetting
+from .decorators import circuitmacro
 from . import pauli
 from . import utils
 from . import vqe
 from . import wq
 from ._version import __version__
 
-__all__ = ["pauli", "utils", "vqe", "wq", "Circuit", "BlueqatGlobalSetting"]
+__all__ = ["pauli", "utils", "vqe", "wq", "circuitmacro", "Circuit", "BlueqatGlobalSetting"]

--- a/blueqat/decorators.py
+++ b/blueqat/decorators.py
@@ -1,0 +1,98 @@
+# Copyright 2019 The Blueqat Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Decorators."""
+from keyword import iskeyword
+from typing import Callable, Union
+
+from .circuit import BlueqatGlobalSetting
+
+
+def circuitmacro(func: Union[Callable, str, None] = None,
+                 *,
+                 allow_overwrite: bool = True) -> Callable:
+    """@circuitmacro decorator.
+
+    Typical usage:
+    Case 1: no arguments
+
+        @def_macro
+        def egg(c):
+            ...
+
+    equivalent to this:
+
+        def egg(c):
+            ...
+        BlueqatGlobalSetting.register_macro('egg', egg, allow_overwrite=True)
+
+
+    Case 2: with name:
+
+        @def_macro('bacon')
+        def egg(c):
+            ...
+
+    is equivalent with
+
+        def egg(c):
+            ...
+        BlueqatGlobalSetting.register_macro('bacon', egg, allow_overwrite=True)
+
+    Case 3: with allow_overwrite keyword argument
+
+        @def_macro(allow_overwrite=False)
+        def egg(c):
+            ...
+
+    or
+
+        @def_macro('bacon', allow_overwrite=False)
+        def bacon(c):
+            ...
+
+    call BlueqatGlobalSetting.register_macro with allow_overwrite=False.
+
+    Please note that `allow_overwrite=True` is default behavior.
+    It is convenient for interactive environment likes Jupyter Notebook.
+    However, if you're library developer, using `allow_overwrite=False` is hardly recommended.
+    """
+    if callable(func):
+        # @def_macro pattern.
+        name = func.__name__
+        if not name.isidentifier() or iskeyword(name):
+            raise ValueError(
+                f'Function name {name} is not a valid macro name. ')
+        BlueqatGlobalSetting.register_macro(name, func, allow_overwrite)
+        return func
+    if isinstance(func, str):
+        # @def_macro(name) or @def_macro(name, allow_overwrite) pattern.
+        name = func
+
+        def _wrapper1(func):
+            BlueqatGlobalSetting.register_macro(name, func, allow_overwrite)
+            return func
+
+        return _wrapper1
+    if func is None:
+        # @def_macro(allow_overwrite) pattern.
+        def _wrapper2(func):
+            name = func.__name__
+            if not name.isidentifier() or iskeyword(name):
+                raise ValueError(
+                    f'Function name {name} is not a valid macro name. ')
+            BlueqatGlobalSetting.register_macro(name, func, allow_overwrite)
+            return func
+
+        return _wrapper2
+    raise TypeError('Invalid type for first argument.')

--- a/blueqat/utils.py
+++ b/blueqat/utils.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 """Utilities for convenient."""
 from collections import Counter
-from typing import Union, Tuple
+from typing import Dict, Tuple, Union
 
 import numpy as np
 
 
 def to_inttuple(
-        bitstr: Union[str, Counter, dict]) -> Union[Tuple[int], Counter, dict]:
+    bitstr: Union[str, Counter, Dict[str, int]]
+) -> Union[Tuple, Counter, Dict[Tuple, int]]:
     """Convert from bit string likes '01011' to int tuple likes (0, 1, 0, 1, 1)
 
     Args:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,85 @@
+import pytest
+import numpy as np
+
+from blueqat import Circuit, circuitmacro
+
+
+@circuitmacro
+def xh(c):
+    return c.x[0].h[1]
+
+
+@circuitmacro()
+def hh(c):
+    return c.h[0, 1]
+
+
+@circuitmacro
+def ryrz(c, p, q):
+    return c.ry(p)[0].rz(q)[0]
+
+
+@circuitmacro('pizza')
+def pasta(c):
+    return c.x[0]
+
+
+def test_macro1():
+    assert np.allclose(Circuit().x[0].h[1].run(), Circuit().xh().run())
+
+
+def test_macro2():
+    assert np.allclose(Circuit().h[0, 1].run(), Circuit().hh().run())
+
+
+def test_macro3():
+    assert np.allclose(Circuit().x[0].run(), Circuit().pizza().run())
+
+
+def test_macro4():
+    with pytest.raises(AttributeError):
+        Circuit().pasta()
+
+
+def test_macro5():
+    assert np.allclose(Circuit().ry(0.3)[0].rz(0.5)[0].run(),
+                       Circuit().ryrz(0.3, 0.5).run())
+
+
+def test_macro6():
+    with pytest.raises(ValueError):
+        @circuitmacro(allow_overwrite=False)
+        def ryrz(c, p):
+            return c.ry(p)[0]
+
+
+def test_macro7():
+    with pytest.raises(ValueError):
+        @circuitmacro(allow_overwrite=False)
+        def run(c):
+            return c
+
+
+def test_macro8():
+    with pytest.warns(UserWarning):
+        @circuitmacro
+        def run(c):
+            return c
+
+
+def test_macro9():
+    with pytest.raises(ValueError):
+        @circuitmacro(allow_overwrite=False)
+        def xh(c):
+            return c
+    assert np.allclose(Circuit().x[0].h[1].run(), Circuit().xh().run())
+
+
+def test_macro10():
+    @circuitmacro
+    def xh(c):
+        return Circuit().x[1].h[0]
+    assert np.allclose(Circuit().x[1].h[0].run(), Circuit().xh().run())
+    @circuitmacro
+    def xh(c):
+        return Circuit().x[0].h[1]


### PR DESCRIPTION
`@circuitmacro` decorator.

Typical usage:
- Case 1: no arguments
```py
        @def_macro
        def egg(c):
            ...
```
equivalent to this:
```py
        def egg(c):
            ...
        BlueqatGlobalSetting.register_macro('egg', egg, allow_overwrite=True)
```

- Case 2: with name:
```py
        @def_macro('bacon')
        def egg(c):
            ...
```
is equivalent with
```py
        def egg(c):
            ...
        BlueqatGlobalSetting.register_macro('bacon', egg, allow_overwrite=True)
```

- Case 3: with allow_overwrite keyword argument
```py
        @def_macro(allow_overwrite=False)
        def egg(c):
            ...
```
or
```py
        @def_macro('egg', allow_overwrite=False)
        def bacon(c):
            ...
```
call BlueqatGlobalSetting.register_macro with allow_overwrite=False.
Please note that `allow_overwrite=True` is default behavior.
It is convenient for interactive environment likes Jupyter Notebook.
However, if you're library developer, using `allow_overwrite=False` is hardly recommended.