### PR TITLE
Gate refactoring

### DIFF
--- a/blueqat/backends/onequbitgate_decomposer.py
+++ b/blueqat/backends/onequbitgate_decomposer.py
@@ -48,7 +48,7 @@ def u_decomposer(gate: OneQubitGate) -> List[UGate]:
     """
     mat = gate.matrix()
     theta, phi, lam, gamma = calc_uparams(mat)
-    return [UGate(gate.targets, theta, phi, lam, gamma)]
+    return [UGate.create(gate.targets, (theta, phi, lam, gamma))]
 
 
 def ryrz_decomposer(gate: OneQubitGate) -> List[Union[RYGate, RZGate]]:
@@ -65,11 +65,11 @@ def ryrz_decomposer(gate: OneQubitGate) -> List[Union[RYGate, RZGate]]:
     if theta < 1e-10:
         if phi + lam < 1e-10:
             return []
-        return [RZGate(gate.targets, phi + lam)]
+        return [RZGate.create(gate.targets, (phi + lam,))]
     ops = []
     if 1e-10 < lam < 2.0 * math.pi - 1e-10:
-        ops.append(RZGate(gate.targets, lam))
+        ops.append(RZGate.create(gate.targets, (lam,)))
     ops.append(RYGate(gate.targets, theta))
     if 1e-10 < phi < 2.0 * math.pi - 1e-10:
-        ops.append(RZGate(gate.targets, phi))
+        ops.append(RZGate.create(gate.targets, (phi,)))
     return ops

--- a/blueqat/backends/onequbitgate_transpiler.py
+++ b/blueqat/backends/onequbitgate_transpiler.py
@@ -12,7 +12,7 @@ _eye = np.eye(2, dtype=complex)
 class OneQubitGateCompactionTranspiler(Backend):
     """Merge one qubit gate."""
     def _run_inner(self, gates, operations: List[Operation],
-                   singlemats: List[np.array], n_qubits: int,
+                   singlemats: List[np.ndarray], n_qubits: int,
                    mat1_decomposer: Callable[[OneQubitGate], List[Operation]]):
         for gate in gates:
             if isinstance(gate, Gate) and gate.n_qargs == 1:
@@ -22,7 +22,7 @@ class OneQubitGateCompactionTranspiler(Backend):
                 for t in gate.target_iter(n_qubits):
                     if not np.allclose(singlemats[t], _eye):
                         operations += mat1_decomposer(
-                            Mat1Gate((t, ), singlemats[t]))
+                            Mat1Gate.create((t, ), (singlemats[t],)))
                         singlemats[t] = _eye.copy()
                 operations.append(gate)
 
@@ -47,5 +47,5 @@ class OneQubitGateCompactionTranspiler(Backend):
                         mat1_decomposer)
         for i, mat in enumerate(singlemats):
             if not np.allclose(mat, _eye):
-                operations += mat1_decomposer(Mat1Gate((i, ), mat))
+                operations += mat1_decomposer(Mat1Gate.create((i, ), (mat,)))
         return Circuit(n_qubits, operations)

--- a/blueqat/gate.py
+++ b/blueqat/gate.py
@@ -13,15 +13,16 @@ import numpy as np
 class Operation:
     """Abstract quantum circuit operation class."""
 
-    lowername: Optional[str] = None
+    lowername: str = ''
     """Lower name of the operation."""
+
     @property
     def uppername(self) -> str:
-        """Upper name of the gate."""
+        """Upper name of the operation."""
         return self.lowername.upper()
 
     def __init__(self, targets, params=(), **kwargs) -> None:
-        if self.lowername is None:
+        if self.lowername == '':
             raise ValueError(
                 f"{self.__class__.__name__}.lowername is not defined.")
         self.params = params

--- a/blueqat/gate.py
+++ b/blueqat/gate.py
@@ -9,6 +9,8 @@ from typing import Callable, Iterable, Iterator, List, NoReturn, Tuple, Type, Ty
 
 import numpy as np
 
+from .typing import Targets
+
 _Op = TypeVar('_Op', bound='Operation')
 
 
@@ -22,7 +24,7 @@ class Operation:
         """Upper name of the operation."""
         return self.lowername.upper()
 
-    def __init__(self, targets, params=(), **kwargs) -> None:
+    def __init__(self, targets: Targets, params=(), **kwargs) -> None:
         if self.lowername == '':
             raise ValueError(
                 f"{self.__class__.__name__}.lowername is not defined.")
@@ -35,8 +37,7 @@ class Operation:
         return slicing(self.targets, n_qubits)
 
     @classmethod
-    def create(cls: Type[_Op], targets: Union[int, slice, tuple],
-            params: tuple) -> _Op:
+    def create(cls: Type[_Op], targets: Targets, params: tuple) -> _Op:
         """Create an operation."""
         raise NotImplementedError(f"{cls.__name__}.create() is not defined.")
 
@@ -1057,7 +1058,7 @@ def slicing_singlevalue(arg: Union[slice, int], length: int) -> Iterator[int]:
         yield i
 
 
-def slicing(args: Tuple[Union[slice, int], ...], length: int) -> Iterator[int]:
+def slicing(args: Targets, length: int) -> Iterator[int]:
     """Internally used."""
     if isinstance(args, tuple):
         for arg in args:
@@ -1066,9 +1067,7 @@ def slicing(args: Tuple[Union[slice, int], ...], length: int) -> Iterator[int]:
         yield from slicing_singlevalue(args, length)
 
 
-def qubit_pairs(args: Tuple[Tuple[Union[slice, int], ...],
-                            Tuple[Union[slice, int], ...]],
-                length: int) -> Iterator[Tuple[int, int]]:
+def qubit_pairs(args: Tuple[Targets, Targets], length: int) -> Iterator[Tuple[int, int]]:
     """Internally used."""
     if not isinstance(args, tuple):
         raise ValueError("Control and target qubits pair(s) are required.")
@@ -1086,7 +1085,7 @@ def qubit_pairs(args: Tuple[Tuple[Union[slice, int], ...],
     return zip(controls, targets)
 
 
-def get_maximum_index(indices: Union[Tuple[int, ...], int]) -> int:
+def get_maximum_index(indices: Targets) -> int:
     """Internally used."""
     def _maximum_idx_single(idx: int):
         if isinstance(idx, slice):

--- a/blueqat/gateset.py
+++ b/blueqat/gateset.py
@@ -1,0 +1,78 @@
+"""This module manages the set of operations, and provides a factory method of operations."""
+
+from typing import Dict, Optional, Type
+
+from . import gate
+from .typing import Targets
+
+GATE_SET: Dict[str, Type[gate.Operation]] = {
+    # 1 qubit gates (alphabetical)
+    "h": gate.HGate,
+    "i": gate.IGate,
+    "mat1": gate.Mat1Gate,
+    "p": gate.PhaseGate,
+    "phase": gate.PhaseGate,
+    "r": gate.PhaseGate,
+    "rx": gate.RXGate,
+    "ry": gate.RYGate,
+    "rz": gate.RZGate,
+    "s": gate.SGate,
+    "sdg": gate.SDagGate,
+    "sx": gate.SXGate,
+    "sxdg": gate.SXDagGate,
+    "t": gate.TGate,
+    "tdg": gate.TDagGate,
+    "u": gate.UGate,
+    "x": gate.XGate,
+    "y": gate.YGate,
+    "z": gate.ZGate,
+    # Controlled gates (alphabetical)
+    "ccx": gate.ToffoliGate,
+    "ccz": gate.CCZGate,
+    "cnot": gate.CXGate,
+    "ch": gate.CHGate,
+    "cp": gate.CPhaseGate,
+    "cphase": gate.CPhaseGate,
+    "cr": gate.CPhaseGate,
+    "crx": gate.CRXGate,
+    "cry": gate.CRYGate,
+    "crz": gate.CRZGate,
+    "cswap": gate.CSwapGate,
+    "cu": gate.CUGate,
+    "cx": gate.CXGate,
+    "cy": gate.CYGate,
+    "cz": gate.CZGate,
+    "toffoli": gate.ToffoliGate,
+    # Other multi qubit gates (alphabetical)
+    "rxx": gate.RXXGate,
+    "ryy": gate.RYYGate,
+    "rzz": gate.RZZGate,
+    "swap": gate.SwapGate,
+    "zz": gate.ZZGate,
+    # Measure and reset (alphabetical)
+    "m": gate.Measurement,
+    "measure": gate.Measurement,
+    "reset": gate.Reset,
+}
+
+def get_op_type(name: str) -> Optional[Type[gate.Operation]]:
+    """Get a class of operation from operation name."""
+    return GATE_SET.get(name)
+
+def create(name: str, targets: Targets, params: tuple) -> gate.Operation:
+    """Create an operation from name, targets and params."""
+    op_type = get_op_type(name)
+    if op_type is None:
+        raise ValueError(f"Unknown operation `{name}'.")
+    return op_type.create(targets, params)
+
+def register_operation(name: str, op_type: Type[gate.Operation]) -> None:
+    """Register an operation. If operation is already exists, overwrite it."""
+    GATE_SET[name] = op_type
+
+def unregister_operation(name: str) -> None:
+    """Unregister an operation. If operation is not exists, do nothing."""
+    try:
+        del GATE_SET[name]
+    except KeyError:
+        pass

--- a/blueqat/typing.py
+++ b/blueqat/typing.py
@@ -1,0 +1,5 @@
+"""This module provides for type hinting."""
+
+from typing import Union
+
+Targets = Union[int, slice, tuple]


### PR DESCRIPTION
- Add Gate.create method. This implementation is required.
- Remove circuit-local default backend, because this feature is not used.
- Add gateset module, it defines the set of operations, the method of creating an operation