### PR TITLE
NumPy 1.21.0 may not yet support Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.21.0
+numpy>=1.21.0
 scipy>=1.5
 networkx>=2.6.3
 matplotlib>=3.5.1


### PR DESCRIPTION
setup.py:63: RuntimeWarning: NumPy 1.21.0 may not yet support Python 3.10.
note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for numpy
Failed to build numpy
ERROR: Could not build wheels for numpy, which is required to install pyproject.toml-based projects
---------
After removing all the restrictions, the installation took place without any problems.
-----------
Uninstalling blueqat-2.0.0:
      Successfully uninstalled blueqat-2.0.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
openfermionblueqat 0.2.2 requires blueqat~=0.3.3, but you have blueqat 2.0.2 which is incompatible.
Successfully installed blueqat-2.0.2