### PR TITLE
feat: resolve remaining open issues (#28, #42, #116, #151)

### DIFF
--- a/blueqat/backends/__init__.py
+++ b/blueqat/backends/__init__.py
@@ -23,6 +23,7 @@ from typing import Any, Dict
 from blueqat.backends.backendbase import Backend, get_backend, register_backend
 from blueqat.backends.torch_backend import TorchBackend
 from blueqat.backends.draw_backend import DrawCircuit
+from blueqat.backends.tn_draw_backend import TNGraphDrawBackend
 from blueqat.backends.onequbitgate_transpiler import OneQubitGateCompactionTranspiler
 from blueqat.backends.twoqubitgate_transpiler import TwoQubitGateDecomposingTranspiler
 from .flexible_circuit_composer import FlexibleCircuitComposer
@@ -43,6 +44,7 @@ BACKENDS: Dict[str, Any] = {
     
     # ユーティリティ
     "draw": DrawCircuit,
+    "draw_tn": TNGraphDrawBackend,
 }
 
 # デフォルトバックエンドを純PyTorch状態ベクトルに設定

--- a/blueqat/backends/tn_draw_backend.py
+++ b/blueqat/backends/tn_draw_backend.py
@@ -1,0 +1,71 @@
+# Copyright 2019-2026 The Blueqat Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend for visualizing the tensor-network graph structure (nodes = tensors,
+edges = contracted/shared indices) that TorchBackend's tensornet mode builds.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from ..gate import Operation
+from .backendbase import Backend
+from .torch_backend import TorchBackend, TorchBackendContext
+
+
+class TNGraphDrawBackend(Backend):
+    """Backend which draws the tensor-network contraction graph for a circuit,
+    instead of running it. Each gate/initial-qubit tensor is a node; an edge
+    connects two tensors that share a contracted axis. Still-open (uncontracted)
+    qubit legs are drawn as dangling leaf nodes.
+    """
+
+    def run(self, gates: List[Operation], n_qubits: int, *args: Any, **kwargs: Any) -> Any:
+        import matplotlib.pyplot as plt
+        import networkx as nx
+
+        device = kwargs.get('device', torch.device('cpu'))
+        dtype = kwargs.get('dtype', torch.complex128)
+        show = kwargs.get('show', True)
+
+        tn_backend = TorchBackend(mode='tensornet', device=device, dtype=dtype)
+        ctx = TorchBackendContext(n_qubits, 'tensornet', device, dtype)
+        ctx = tn_backend._run_inner(ctx, gates, n_qubits)
+
+        graph = nx.MultiGraph()
+        for i, tensor in enumerate(ctx.tensors):
+            graph.add_node(i, shape=tuple(tensor.shape))
+
+        axis_to_nodes: Dict[int, List[int]] = {}
+        for i, idxs in enumerate(ctx.tensor_indices):
+            for axis in idxs:
+                axis_to_nodes.setdefault(axis, []).append(i)
+
+        for axis, nodes in axis_to_nodes.items():
+            if len(nodes) == 2:
+                graph.add_edge(nodes[0], nodes[1], label=str(axis))
+            elif len(nodes) == 1:
+                leaf = f'open_{axis}'
+                graph.add_node(leaf, shape=None, open_leg=True)
+                graph.add_edge(nodes[0], leaf, label=f'q{axis}')
+            # a well-formed tensor network never shares one axis across more
+            # than 2 tensors, so any other case is left undrawn defensively.
+
+        if show:
+            pos = nx.spring_layout(graph, seed=0)
+            node_colors = ['white' if graph.nodes[n].get('open_leg') else '#0BB0E2' for n in graph.nodes]
+            nx.draw_networkx(graph, pos, node_color=node_colors, with_labels=True)
+            plt.show()
+
+        return graph

--- a/blueqat/circuit.py
+++ b/blueqat/circuit.py
@@ -181,6 +181,58 @@ class Circuit:
         vec, cnt = backend.run(self.ops, self.n_qubits, shots=1, returns='statevector_and_shots', **kwargs)
         return vec, next(iter(cnt))
 
+    def ancilla(self, n: int = 1, pos: Optional[int] = None, stop: Optional[int] = None,
+                reset: bool = True) -> '_AncillaContext':
+        """Context manager allocating temporary ancilla qubit(s) for use inside the `with` block.
+
+        By default, appends `n` fresh qubits past the circuit's current width:
+
+            with c.ancilla() as a:
+                c.cx[0, a[0]]
+
+        `pos`/`stop` instead pin the ancilla range to specific qubit indices
+        (`range(pos, stop)`; `stop` defaults to `pos + n`):
+
+            with c.ancilla(pos=4, stop=6, reset=True) as a:
+                c.cx[3, a[0]]
+
+        If `reset` is true (the default), a `reset` gate is appended for each
+        ancilla qubit on exiting the block, so they're back at |0> and safe to
+        reuse elsewhere in the circuit.
+        """
+        if pos is not None:
+            indices = list(range(pos, stop if stop is not None else pos + n))
+            self.n_qubits = max(self.n_qubits, (max(indices) + 1) if indices else 0)
+        else:
+            indices = list(range(self.n_qubits, self.n_qubits + n))
+            self.n_qubits += n
+        return _AncillaContext(self, indices, reset)
+
+
+class _AncillaContext:
+    """Context manager returned by `Circuit.ancilla()`. See that method's docstring."""
+    def __init__(self, circuit: Circuit, indices: list, reset: bool) -> None:
+        self.circuit = circuit
+        self.indices = indices
+        self.reset = reset
+
+    def __getitem__(self, i: int) -> int:
+        return self.indices[i]
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __enter__(self) -> '_AncillaContext':
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self.reset and exc_type is None:
+            for idx in self.indices:
+                self.circuit.reset[idx]
+
 
 class _GateWrapper(CircuitOperation[Circuit]):
     def __init__(self, circuit: Circuit, op_type: Type['Operation']):

--- a/blueqat/circuit_funcs/__init__.py
+++ b/blueqat/circuit_funcs/__init__.py
@@ -15,8 +15,10 @@
 
 from .circuit_to_unitary import circuit_to_unitary
 from .flatten import flatten
+from .qasm_parser import from_qasm
 
 __all__ = [
     'circuit_to_unitary',
     'flatten',
+    'from_qasm',
 ]

--- a/blueqat/circuit_funcs/qasm_parser.py
+++ b/blueqat/circuit_funcs/qasm_parser.py
@@ -1,0 +1,125 @@
+# Copyright 2019-2026 The Blueqat Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parser for a practical subset of OpenQASM 2.0 (the qelib1.inc gate set) into a Circuit.
+
+This is the reverse of `Circuit.to_qasm()`.
+"""
+
+import ast
+import math
+import operator
+import re
+from typing import List
+
+from ..circuit import Circuit
+
+# name -> (blueqat gate name, number of numeric args)
+_GATES = {
+    # no-arg 1-qubit
+    'x': ('x', 0), 'y': ('y', 0), 'z': ('z', 0), 'h': ('h', 0),
+    's': ('s', 0), 'sdg': ('sdg', 0), 't': ('t', 0), 'tdg': ('tdg', 0),
+    'sx': ('sx', 0), 'sxdg': ('sxdg', 0), 'id': ('i', 0), 'reset': ('reset', 0),
+    # 1-arg 1-qubit
+    'rx': ('rx', 1), 'ry': ('ry', 1), 'rz': ('rz', 1),
+    'p': ('phase', 1), 'u1': ('phase', 1),
+    # 3-arg 1-qubit
+    'u': ('u', 3), 'u3': ('u', 3),
+    # no-arg 2-qubit
+    'cx': ('cx', 0), 'cz': ('cz', 0), 'cy': ('cy', 0), 'ch': ('ch', 0), 'swap': ('swap', 0),
+    # 1-arg 2-qubit
+    'cp': ('cphase', 1), 'cu1': ('cphase', 1),
+    'crx': ('crx', 1), 'cry': ('cry', 1), 'crz': ('crz', 1),
+    'rxx': ('rxx', 1), 'ryy': ('ryy', 1), 'rzz': ('rzz', 1), 'zz': ('zz', 1),
+    # 4-arg 2-qubit
+    'cu': ('cu', 4),
+    # no-arg 3-qubit
+    'ccx': ('ccx', 0), 'cswap': ('cswap', 0),
+}
+
+_CONSTS = {'pi': math.pi}
+_BINOPS = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow}
+_UNARYOPS = {ast.USub: operator.neg, ast.UAdd: operator.pos}
+
+
+def _eval_angle_expr(node: ast.AST) -> float:
+    """Safely evaluate a numeric angle expression (numbers, +-*/, unary -, and `pi`)
+    without falling back to `eval`, since this parses (potentially untrusted) QASM text."""
+    if isinstance(node, ast.Expression):
+        return _eval_angle_expr(node.body)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in _CONSTS:
+        return _CONSTS[node.id]
+    if isinstance(node, ast.BinOp) and type(node.op) in _BINOPS:
+        return _BINOPS[type(node.op)](_eval_angle_expr(node.left), _eval_angle_expr(node.right))
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARYOPS:
+        return _UNARYOPS[type(node.op)](_eval_angle_expr(node.operand))
+    raise ValueError(f"Unsupported expression in QASM angle argument: {ast.dump(node)}")
+
+
+def _parse_args(args_str: str) -> List[float]:
+    args = []
+    for a in args_str.split(','):
+        try:
+            tree = ast.parse(a.strip(), mode='eval')
+        except SyntaxError as e:
+            raise ValueError(f"Could not parse QASM argument {a!r}: {e}") from e
+        args.append(_eval_angle_expr(tree))
+    return args
+
+
+def _parse_targets(targets_str: str) -> List[int]:
+    return [int(m.group(1)) for m in re.finditer(r'\[(\d+)\]', targets_str)]
+
+
+def from_qasm(qasm: str) -> Circuit:
+    """Parse an OpenQASM 2.0 program (the qelib1.inc gate set) into a Circuit."""
+    c = Circuit()
+    # strip line (//) and block (/* */) comments
+    text = re.sub(r'/\*.*?\*/', '', qasm, flags=re.DOTALL)
+    text = re.sub(r'//.*', '', text)
+
+    for raw_stmt in text.split(';'):
+        stmt = raw_stmt.strip()
+        if not stmt:
+            continue
+        if stmt.startswith(('OPENQASM', 'include', 'qreg', 'creg', 'barrier', 'gate ', 'opaque ')):
+            continue
+
+        measure_match = re.match(r'measure\s+q\[(\d+)\]\s*->\s*c\[(\d+)\]$', stmt)
+        if measure_match:
+            c.m[int(measure_match.group(1))]
+            continue
+
+        gate_match = re.match(r'(\w+)\s*(?:\(([^)]*)\))?\s+(.+)$', stmt)
+        if not gate_match:
+            raise ValueError(f"Could not parse QASM statement: {stmt!r}")
+        name, args_str, targets_str = gate_match.groups()
+
+        if name not in _GATES:
+            raise ValueError(f"Unsupported QASM gate: {name!r}")
+        gate_name, n_args = _GATES[name]
+        args = _parse_args(args_str) if args_str else []
+        if len(args) != n_args:
+            raise ValueError(f"Gate {name!r} expects {n_args} argument(s), got {len(args)}")
+        targets = _parse_targets(targets_str)
+
+        op = getattr(c, gate_name)
+        if args:
+            op = op(*args)
+        target = targets[0] if len(targets) == 1 else tuple(targets)
+        op[target]
+
+    return c

--- a/blueqat/utils.py
+++ b/blueqat/utils.py
@@ -680,11 +680,18 @@ class Vqe:
         self.optimizer_cls = optimizer_cls
         self.optimizer_kwargs = optimizer_kwargs or {"lr": 0.05}
         self.sampler = sampler
+        self.sampler_call_count = 0
 
     def run(self, max_iter: int = 500, tol: float = 1e-6, verbose: bool = False, device: Optional[torch.device] = None,
             initial_params: Optional[torch.Tensor] = None) -> VqeResult:
         if device is None: device = torch.device('cpu')
-        objective_fn = self.ansatz.get_objective(self.sampler, device=device)
+        self.sampler_call_count = 0
+        counting_sampler = None
+        if self.sampler is not None:
+            def counting_sampler(circuit: Circuit, meas: typing.Iterable[int]) -> Dict[Tuple[int, ...], float]:
+                self.sampler_call_count += 1
+                return self.sampler(circuit, meas)
+        objective_fn = self.ansatz.get_objective(counting_sampler, device=device)
 
         if initial_params is None:
             params = torch.rand(self.ansatz.n_params, dtype=torch.float64, device=device, requires_grad=True)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -759,3 +759,35 @@ def test_oneshot_method(backend):
     vec, meas = Circuit().h[0].cx[0, 1].m[:].oneshot(backend=backend)
     assert isinstance(vec, torch.Tensor)
     assert isinstance(meas, str)
+
+
+def test_ancilla_auto(backend):
+    c = Circuit(4).h[0].h[1].h[2].h[3]
+    with c.ancilla() as a:
+        c.cx[0, a[0]]
+        c.cx[0, a[0]]
+    assert c.n_qubits == 5
+    # cx applied twice cancels out, so the ancilla (qubit 4) stays |0>, and the
+    # rest of the state is unchanged from the plain 4-qubit circuit.
+    assert np.allclose(c.run(backend=backend),
+                       Circuit(4).h[0].h[1].h[2].h[3].i[4].run(backend=backend))
+
+
+def test_ancilla_pos_reset(backend):
+    c = Circuit(4).x[0]
+    with c.ancilla(pos=6, stop=8, reset=True) as a:
+        c.cx[0, a[0]]
+    assert c.n_qubits == 8
+    cnt = c.m[:].run(backend=backend, shots=10)
+    # ancilla qubits 6, 7 must be back at |0> after the block exits
+    assert all(bs[0] == '0' and bs[1] == '0' for bs in cnt)
+
+
+def test_ancilla_no_reset(backend):
+    c = Circuit(2).x[0]
+    with c.ancilla(reset=False) as a:
+        c.cx[0, a[0]]
+    assert c.n_qubits == 3
+    cnt = c.m[:].run(backend=backend, shots=10)
+    # ancilla qubit 2 keeps the cx's effect since reset=False
+    assert all(bs[0] == '1' for bs in cnt)

--- a/tests/test_draw_backends.py
+++ b/tests/test_draw_backends.py
@@ -1,0 +1,27 @@
+import matplotlib
+matplotlib.use('Agg')  # headless: avoid blocking on an interactive plt.show()
+
+from blueqat import Circuit
+
+
+def test_draw_circuit_backend():
+    result = Circuit().h[0].cx[0, 1].m[:].run(backend='draw')
+    # DrawCircuit returns the raw layout data alongside layout bookkeeping.
+    assert isinstance(result, tuple)
+    qlist = result[0]
+    assert 0 in qlist and 1 in qlist
+
+
+def test_draw_tn_backend_structure():
+    graph = Circuit().h[0].cx[0, 1].h[1].run(backend='draw_tn', show=False)
+    # 2 initial-qubit tensors + h + cx + h = 5 real tensor nodes, plus 2 open legs.
+    real_nodes = [n for n in graph.nodes if not graph.nodes[n].get('open_leg')]
+    open_nodes = [n for n in graph.nodes if graph.nodes[n].get('open_leg')]
+    assert len(real_nodes) == 5
+    assert len(open_nodes) == 2
+    assert graph.number_of_edges() == 6
+
+
+def test_draw_tn_backend_show_renders():
+    # Should not raise even with show=True (the default), using the Agg backend.
+    Circuit().h[0].cx[0, 1].run(backend='draw_tn')

--- a/tests/test_toqasm.py
+++ b/tests/test_toqasm.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
+import numpy as np
+import pytest
+
 from blueqat import Circuit
+from blueqat.circuit_funcs import from_qasm
 
 QASM = """OPENQASM 2.0;
 include "qelib1.inc";
@@ -70,3 +76,33 @@ def test_qasm_noprologue2():
     c = Circuit().x[0].y[0].z[0]
     qasm = c.to_qasm(False)
     assert qasm == correct_qasm
+
+def test_from_qasm_roundtrip():
+    c = from_qasm(QASM)
+    assert c.to_qasm() == QASM
+
+def test_from_qasm_angle_expressions():
+    qasm = """rx(pi/2) q[0];
+ry(-pi/4) q[1];
+crx(pi) q[0],q[1];"""
+    c = from_qasm(qasm)
+    expected = Circuit(2).rx(math.pi / 2)[0].ry(-math.pi / 4)[1].crx(math.pi)[0, 1]
+    assert np.allclose(c.run(), expected.run())
+
+def test_from_qasm_multi_qubit_gates():
+    qasm = """ccx q[0],q[1],q[2];
+cswap q[0],q[1],q[2];
+sdg q[3];
+tdg q[3];
+rzz(0.5) q[2],q[3];"""
+    c = from_qasm(qasm)
+    expected = Circuit(4).ccx[0, 1, 2].cswap[0, 1, 2].sdg[3].tdg[3].rzz(0.5)[2, 3]
+    assert np.allclose(c.run(), expected.run())
+
+def test_from_qasm_rejects_unsafe_expressions():
+    with pytest.raises(ValueError):
+        from_qasm('rx(__import__("os")) q[0];')
+
+def test_from_qasm_rejects_unknown_gate():
+    with pytest.raises(ValueError):
+        from_qasm('bogusgate q[0];')


### PR DESCRIPTION
## Summary
- #28: `Vqe` now tracks `sampler_call_count`, reset at the start of each `run()`.
- #42: Add `blueqat.circuit_funcs.from_qasm()`, a parser for the qelib1.inc OpenQASM 2.0 subset that `Circuit.to_qasm()` emits (round-trips exactly). Angle arguments are evaluated with a restricted AST walker rather than `eval()`, since this parses untrusted text.
- #116: Add `Circuit.ancilla()` context manager for temporary qubit allocation, with optional `pos`/`stop` pinning and reset-on-exit.
- #151: Add a `"draw_tn"` backend (`TNGraphDrawBackend`) that visualizes the tensornet backend's contraction graph via networkx (tensors as nodes, shared axes as edges, open qubit legs as dangling leaf nodes).

## Test plan
- [x] `pytest tests/` — 1357 passed

Closes #28, #42, #116, #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)