### PR TITLE
docs: update README and fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ gradients through `Circuit.run()`.
 ### Tutorial
 https://github.com/Blueqat/Blueqat-tutorials
 
+### Examples
+Runnable scripts in [`examples/`](examples/):
+- `bell_state.py` -- circuit basics: statevector, single amplitude, shot sampling
+- `vqe_ground_state.py` -- VQE with a custom `AnsatzBase` (not tied to QAOA)
+- `maxcut_qaoa.py` -- QAOA for the graph Max-Cut problem
+- `numpartition_qaoa.py` -- QAOA for number partitioning
+
 ### Install
 ```
 git clone https://github.com/blueqat/blueqatSDK

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # blueqat
 A Quantum Computing SDK
 
+Blueqat's simulator is built on PyTorch, with two selectable execution modes:
+a dense **statevector** simulator and a memory-scalable **tensornet**
+(tensor-network contraction) simulator, which is the default. Both are
+differentiable, so circuits with `torch.Tensor` parameters keep their
+gradients through `Circuit.run()`.
+
 ### Tutorial
 https://github.com/Blueqat/Blueqat-tutorials
 
@@ -49,7 +55,11 @@ Circuit().rz(math.pi / 4)[0]
 ### Run
 ```python
 from blueqat import Circuit
-Circuit(50).h[:].run()
+Circuit(20).h[:].run() # returns a torch.Tensor statevector
+
+# Select the execution mode explicitly (tensornet is the default)
+Circuit(20).h[:].run(mode="statevector")
+Circuit(20).h[:].run(mode="tensornet")
 ```
 
 ### Run(shots=n)
@@ -58,88 +68,139 @@ Circuit(100).x[:].run(shots=1)
 # => Counter({'1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111': 1})
 ```
 
+### Large-scale circuits
+The dense statevector has `2**n_qubits` entries, so for large `n_qubits` in
+`tensornet` mode (the default), `run()` requires either `shots=` or
+`returns="amplitude"` instead of materializing the full vector:
+```python
+Circuit(50).h[:].run(shots=3)
+Circuit(50).h[:].run(returns="amplitude", amplitude="0" * 50)
+```
+
 ### Single Amplitude
 ```python
 Circuit(4).h[:].run(amplitude="0101")
 ```
 
+### Reset and mid-circuit measurement
+```python
+# reset[i] forces qubit i back to |0>. Any circuit containing reset is run
+# shot-by-shot with a real probabilistic collapse at each measure/reset.
+Circuit(2).h[0].cx[0, 1].reset[0].m[:].run(shots=100)
+
+# Measurement keys let you tag a measurement and read it back per-shot.
+Circuit().x[0].m(key="a")[0].run(shots=10, returns="samples")
+# => [{'a': [1]}, {'a': [1]}, ...]
+```
+
+### Ancilla qubits
+```python
+c = Circuit(4).h[0].h[1].h[2].h[3]
+with c.ancilla() as a:       # allocate a fresh qubit past the current width
+    c.cx[0, a[0]]
+    c.cx[0, a[0]]
+with c.ancilla(pos=6, stop=8, reset=True) as a:  # or pin an explicit range
+    c.cx[3, a[0]]
+# a[i] is reset back to |0> on exiting the `with` block when reset=True (the default)
+```
+
 ### Expectation value of hamiltonian
 ```python
-from blueqat.pauli import Z
+from blueqat.utils import Z
 hamiltonian = 1*Z[0]+1*Z[1]
 Circuit(4).x[:].run(hamiltonian=hamiltonian)
 # => -2.0
 ```
 
-### Blueqat to QASM
+### Blueqat to/from QASM
 ```python
 Circuit().h[0].to_qasm()
-    
+
 #OPENQASM 2.0;
 #include "qelib1.inc";
 #qreg q[1];
 #creg c[1];
 #h q[0];
+
+from blueqat.circuit_funcs import from_qasm
+from_qasm(Circuit().h[0].to_qasm())  # parses back into an equivalent Circuit
 ```
 
 ### Hamiltonian
 ```python
-from blueqat.pauli import *
+from blueqat.utils import X, Y, Z, I
 
-hamiltonian1 = (1.23 * Z[0] + 4.56 * X[1] * Z[2]) ** 2
-hamiltonian2 = (2.46 * Y[0] + 5.55 * Z[1] * X[2] * X[1]) ** 2
-hamiltonian = hamiltonian1 + hamiltonian2
+h1 = 1.23 * Z[0] + 4.56 * X[1] * Z[2]
+h2 = 2.46 * Y[0] + 5.55 * Z[1] * X[2] * X[1]
+hamiltonian = h1 * h1 + h2 * h2
 print(hamiltonian)
-    
-# => 7.5645*I + 5.6088*Z[0]*X[1]*Z[2] + 5.6088*X[1]*Z[2]*Z[0] + 20.793599999999998*X[1]*Z[2]*X[1]*Z[2] + 13.652999999999999*Y[0]*Z[1]*X[2]*X[1] + 13.652999999999999*Z[1]*X[2]*X[1]*Y[0] + 30.8025*Z[1]*X[2]*X[1]*Z[1]*X[2]*X[1]
 ```
 
 ### Simplify the Hamiltonian
 ```python
 hamiltonian = hamiltonian.simplify()
 print(hamiltonian)
-
-#=>-2.4444000000000017*I + 27.305999999999997j*Y[0]*Y[1]*X[2] + 11.2176*Z[0]*X[1]*Z[2]
 ```
 
 ### QUBO Hamiltonian
 ```python
-from blueqat.pauli import qubo_bit as q
+from blueqat.utils import qubo_bit as q
 
 hamiltonian = -3*q(0)-3*q(1)-3*q(2)-3*q(3)-3*q(4)+2*q(0)*q(1)+2*q(0)*q(2)+2*q(0)*q(3)+2*q(0)*q(4)
 print(hamiltonian)
-    
-# => -5.5*I + 1.0*Z[1] + 1.0*Z[2] + 1.0*Z[3] + 1.0*Z[4] + 0.5*Z[0]*Z[1] + 0.5*Z[0]*Z[2] + 0.5*Z[0]*Z[3] - 0.5*Z[0] + 0.5*Z[0]*Z[4]
 ```
 
 ### Time Evolution
 ```python
-hamiltonian = [1.0*Z(0), 1.0*X[0]]
+import numpy as np
+from blueqat import Circuit
+from blueqat.utils import Z, X
+
+hamiltonian = [1.0*Z[0], 1.0*X[0]]
 a = [term.get_time_evolution() for term in hamiltonian]
 
 time_evolution = Circuit().h[0]
 for evo in a:
     evo(time_evolution, np.random.rand())
-    
-print(time_evolution)
 
-# => Circuit(1).h[0].rz(-1.4543063361067243)[0].h[0].rz(-1.8400416676737137)[0].h[0]
+print(time_evolution)
+```
+
+### VQE
+```python
+import torch
+from blueqat import Circuit
+from blueqat.utils import Z, AnsatzBase, Vqe
+
+class MyAnsatz(AnsatzBase):
+    def get_circuit(self, params: torch.Tensor) -> Circuit:
+        return Circuit(1).rx(params[0])[0]
+
+hamiltonian = 1.0 * Z[0]
+vqe = Vqe(MyAnsatz(hamiltonian, n_params=1))
+result = vqe.run(initial_params=torch.tensor([0.1]))  # initial_params is optional
+print(result.params, result.circuit.run())
+print(vqe.sampler_call_count)  # 0 unless a sampler was supplied to Vqe(...)
 ```
 
 ### QAOA
 ```python
-from blueqat import Circuit
-from blueqat.utils import qaoa
-from blueqat.pauli import qubo_bit as q
-from blueqat.pauli import X,Y,Z,I
+from blueqat.utils import qubo_bit as q, QaoaAnsatz, Vqe
 
 hamiltonian = q(0)-q(1)
 step = 1
 
-result = qaoa(hamiltonian, step)
+vqe = Vqe(QaoaAnsatz(hamiltonian, step))
+result = vqe.run()
 result.circuit.run(shots=100)
-    
+
 # => Counter({'10': 100})
+```
+
+### Drawing
+```python
+Circuit().h[0].cx[0, 1].m[:].run(backend="draw")     # circuit diagram
+Circuit().h[0].cx[0, 1].run(backend="draw_tn")        # tensor-network graph
 ```
 
 ### Document

--- a/examples/bell_state.py
+++ b/examples/bell_state.py
@@ -1,0 +1,31 @@
+"""Blueqat basics: build a Bell state, inspect its statevector, and sample it.
+
+A Bell state (|00> + |11>) / sqrt(2) is the simplest example of entanglement:
+measuring either qubit is a fair coin flip, but the two outcomes are always
+identical. This script builds one with a Hadamard and a CNOT, and shows the
+statevector, single-amplitude, and shot-sampling ways to inspect a circuit.
+"""
+from collections import Counter
+
+from blueqat import Circuit
+
+
+if __name__ == "__main__":
+    print("Bell state basics")
+    print("=" * 50)
+
+    circuit = Circuit(2).h[0].cx[0, 1]
+
+    # 1. The full statevector (a torch.Tensor, gradient-friendly).
+    state = circuit.run()
+    print(f"Statevector: {state}")
+
+    # 2. A single amplitude, without ever building the full vector.
+    amp_00 = circuit.run(returns="amplitude", amplitude="00")
+    print(f"Amplitude of |00>: {amp_00}")
+
+    # 3. Sampling: measuring collapses the superposition into shot outcomes.
+    counts: Counter = circuit.m[:].run(shots=1000)
+    print(f"1000 shots: {counts}")
+    assert set(counts) <= {"00", "11"}, "Bell state should only ever show 00 or 11"
+    print("(only '00' and '11' ever appear -- that's the entanglement)")

--- a/examples/maxcut_qaoa.py
+++ b/examples/maxcut_qaoa.py
@@ -1,56 +1,43 @@
-import os
-import sys
-import torch
+"""Max-Cut optimization via QAOA.
 
-# 1. 自作SDKの探索パスを設定
-SDK_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if SDK_ROOT not in sys.path:
-    sys.path.insert(0, SDK_ROOT)
+Given a graph, Max-Cut asks for a 2-coloring of its vertices that maximizes
+the number of edges crossing between the two colors. Encoding "vertex i and j
+have different colors" as minimizing <Z_i Z_j> gives a natural QAOA cost
+Hamiltonian: H = sum over edges (i, j) of Z_i * Z_j.
+"""
+from typing import Callable, List, Optional, Tuple
 
-from blueqat import pauli, vqe
-from blueqat.backends.torch_backend import TorchBackend
+from blueqat.utils import Vqe, QaoaAnsatz, Z
 
-def maxcut_qaoa(n_step, edges, sampler=None):
-    """Setup Modern QAOA for Max-Cut problem using PyTorch VQE.
 
-    :param n_step: QAOAのステップ数
-    :param edges: グラフの辺リスト
-    :returns Vqe オブジェクト
+def maxcut_qaoa(n_step: int, edges: List[Tuple[int, int]],
+                sampler: Optional[Callable] = None) -> Vqe:
+    """Build a Vqe runner for the Max-Cut problem on the given graph.
+
+    :param n_step: Number of QAOA layers (p).
+    :param edges: List of (i, j) edges of the graph.
+    :param sampler: Optional custom sampler, passed through to Vqe.
+    :returns: A Vqe instance, ready to call `.run()` on.
     """
-    # ハミルトニアンの初期化
-    hamiltonian = pauli.I() * 0
-
-    # Max-Cut問題の定式化: 隣り合う頂点が「異なる状態」のときにエネルギーが下がるように設計
+    hamiltonian = 0
     for i, j in edges:
-        hamiltonian += pauli.Z(i) * pauli.Z(j)
+        hamiltonian = hamiltonian + Z[i] * Z[j]
 
-    hamiltonian = hamiltonian.simplify()
+    ansatz = QaoaAnsatz(hamiltonian, n_step)
+    return Vqe(ansatz, sampler=sampler)
 
-    # 💡 2026年最新仕様: 引数は ansatz と sampler のみでシンプルに構築
-    ansatz = vqe.QaoaAnsatz(hamiltonian, n_step)
-    return vqe.Vqe(ansatz, sampler=sampler)
 
 if __name__ == "__main__":
-    print("==================================================")
-    print("🎨 自作 TorchBackend + 新型VQE による Max-Cut 最適化")
-    print("==================================================")
-    
-    # グラフの定義とランナーの生成
+    print("Max-Cut via QAOA")
+    print("=" * 50)
+
     graph_edges = [(0, 1), (1, 2), (2, 3), (3, 0), (1, 3), (0, 2), (4, 0), (4, 3)]
     runner = maxcut_qaoa(2, graph_edges)
-    
-    # 💡 パラメータをじっくり更新させるために max_iter=300 で実行
-    # 裏側では自動的に PyTorch Adam と自作の TorchBackend が駆動します
-    result = runner.run(max_iter=300, verbose=True)
-    
-    # 最も確率の高かったビット配置（グループ分け）を取得
+
+    result = runner.run(max_iter=300)
     best_config = result.most_common()[0][0]
-    
-    print("--------------------------------------------------")
-    print("✨ 最適化完了！グラフのカット結果を出力します:")
-    print(f"頂点配置 (q0, q1, q2, q3, q4) = {best_config}")
-    
-    # アスキーアートに結果の 0 / 1 をマッピングして表示
+
+    print(f"Best partition (q0..q4) = {best_config}")
     print("""
          {4}
         / \\
@@ -58,4 +45,3 @@ if __name__ == "__main__":
        | x |
        {1}---{2}
 """.format(*best_config))
-    print("==================================================")

--- a/examples/numpartition_qaoa.py
+++ b/examples/numpartition_qaoa.py
@@ -1,117 +1,56 @@
-import os
-import sys
+"""Number partitioning via QAOA.
+
+Given a list of numbers, split them into two groups whose sums are as close
+as possible. Encoding group membership as a spin (+-1) per number, the
+imbalance squared (sum_i x_i * s_i) ** 2 is minimized exactly when the two
+groups' sums match -- a natural QAOA cost Hamiltonian once s_i is replaced by
+the Pauli operator Z_i.
+
+QAOA is a heuristic: at low depth it usually doesn't put all its probability
+on the single best answer, so in practice you sample several of the most
+likely bitstrings and pick the best one, as this script does.
+"""
+from typing import List
+
 import torch
-import math
 
-torch.manual_seed(42) # 乱数のシードを固定
+from blueqat.utils import Vqe, QaoaAnsatz, Z
 
-# 1. 自作SDKの探索パスを設定
-SDK_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if SDK_ROOT not in sys.path:
-    sys.path.insert(0, SDK_ROOT)
+torch.manual_seed(42)
 
-from blueqat import Circuit, pauli
-from blueqat.backends.torch_backend import TorchBackend
 
-def run_torch_qaoa_example():
-    print("==================================================")
-    # 💡 2. 解きたい数値分割問題
-    # ==================================================
-    nums = [3, 2, 6, 9, 2, 5, 7, 3] # 合計 37 (できるだけ差が小さくなるように分ける)
-    n_qubits = len(nums)
-    n_step = 2  # QAOAのステップ数
-    
-    print(f"🧮 入力数値リスト: {nums} (要素数: {n_qubits})")
-    print("🎯 目標: 合計が均等になる2つのグループに分割する")
-    print("--------------------------------------------------")
-
-    # ==================================================
-    # 📐 3. ハミルトニアン（コスト関数）の設計
-    # ==================================================
-    hamiltonian = pauli.Expr.zero()
+def numpartition_hamiltonian(nums: List[int]):
+    """Cost Hamiltonian for partitioning `nums` into two equal-sum groups."""
+    imbalance = 0
     for i, x in enumerate(nums):
-        hamiltonian += pauli.Z[i] * x
-    hamiltonian = (hamiltonian ** 2).simplify()
+        imbalance = imbalance + x * Z[i]
+    return (imbalance * imbalance).simplify()
 
-    # ==================================================
-    # 🧠 4. PyTorchによる変分パラメータ（角度）の最適化
-    # ==================================================
-    angles = torch.tensor([0.1] * (2 * n_step), dtype=torch.float64, requires_grad=True)
-    
-    # 最適化群 Adam
-    optimizer = torch.optim.Adam([angles], lr=0.1)
-    
-    print("🚀 PyTorch Autograd を用いた QAOA パラメータ最適化を開始します...")
-    
-    for epoch in range(50):
-        optimizer.zero_grad()
-        
-        from blueqat.vqe import QaoaAnsatz
-        ansatz = QaoaAnsatz(hamiltonian, n_step)
-        circuit = ansatz.get_circuit(angles)
-        
-        # 自作の TorchBackend で実行
-        backend = TorchBackend(mode="statevector")
-        statevector = circuit.run(backend=backend)
-        
-        probs = torch.abs(statevector) ** 2
-        indices = torch.arange(len(probs), device=angles.device)
-        energy_diagonal = torch.zeros_like(probs, dtype=torch.float64)
-        
-        # 各パウリ項の期待値を計算
-        for term, coeff in hamiltonian.terms:
-            # 💡 【修正ポイント】定数項（termが空）の安全な処理
-            if not term:
-                energy_diagonal += coeff
-                continue
-                
-            term_sign = torch.ones_like(probs, dtype=torch.float64)
-            
-            # term の要素を安全に展開
-            for tuple_item in term:
-                # tuple_item が (qubit_idx, 'Z') であることを保証
-                if isinstance(tuple_item, tuple) and len(tuple_item) == 2:
-                    qubit_idx, op = tuple_item
-                    if op == 'Z':
-                        # ビット位置を考慮したマスク計算（左が q0 の Blueqat 仕様に準拠）
-                        bit = (indices >> (n_qubits - 1 - qubit_idx)) & 1
-                        sign = 1.0 - 2.0 * bit.to(torch.float64)
-                        term_sign *= sign
-            
-            energy_diagonal += coeff * term_sign
-        
-        # 期待値の総和を Loss とする
-        loss = torch.sum(probs * energy_diagonal)
-        
-        loss.backward()
-        optimizer.step()
-        
-        if (epoch + 1) % 10 == 0:
-            print(f"Epoch {epoch+1:2d}/50 | エネルギー期待値 (Loss): {loss.item():.4f}")
-
-    # ==================================================
-    # 🏁 5. 最適化結果の解析と出力
-    # ==================================================
-    print("--------------------------------------------------")
-    print("✨ 最適化完了！ 最終的な状態ベクトルから最頻出の組み合わせを抽出します...")
-    
-    final_circuit = QaoaAnsatz(hamiltonian, n_step).get_circuit(angles.detach())
-    final_state = final_circuit.run(backend=TorchBackend(mode="statevector"))
-    
-    probs = torch.abs(final_state) ** 2
-    best_idx = torch.argmax(probs).item()
-    
-    fmt = f"0{n_qubits}b"
-    result_bits = format(best_idx, fmt)
-    
-    group0 = [a for a, b in zip(nums, result_bits) if b == '0']
-    group1 = [a for a, b in zip(nums, result_bits) if b == '1']
-    
-    print(f"📊 最適なビット列: {result_bits}")
-    print(f"👥 グループ 0 (合計: {sum(group0):2d}): {group0}")
-    print(f"👥 グループ 1 (合計: {sum(group1):2d}): {group1}")
-    print(f"⚖️ 両グループの差分: {abs(sum(group0) - sum(group1))}")
-    print("==================================================")
 
 if __name__ == "__main__":
-    run_torch_qaoa_example()
+    print("Number partitioning via QAOA")
+    print("=" * 50)
+
+    nums = [3, 2, 6, 9, 2, 5, 7, 3]
+    print(f"Numbers: {nums} (total: {sum(nums)})")
+
+    hamiltonian = numpartition_hamiltonian(nums)
+    vqe = Vqe(QaoaAnsatz(hamiltonian, step=3))
+    result = vqe.run(max_iter=500)
+
+    # Look at the top candidates and keep the best-balanced one.
+    candidates = result.most_common(5)
+    best_bits, best_diff = None, None
+    for bits, _ in candidates:
+        group0 = [x for x, b in zip(nums, bits) if b == 0]
+        group1 = [x for x, b in zip(nums, bits) if b == 1]
+        diff = abs(sum(group0) - sum(group1))
+        if best_diff is None or diff < best_diff:
+            best_bits, best_diff = bits, diff
+
+    group0 = [x for x, b in zip(nums, best_bits) if b == 0]
+    group1 = [x for x, b in zip(nums, best_bits) if b == 1]
+    print(f"Best bitstring found: {best_bits}")
+    print(f"Group 0 (sum={sum(group0)}): {group0}")
+    print(f"Group 1 (sum={sum(group1)}): {group1}")
+    print(f"Difference: {best_diff}")

--- a/examples/vqe_ground_state.py
+++ b/examples/vqe_ground_state.py
@@ -1,0 +1,43 @@
+"""VQE basics: find the ground-state energy of a single-qubit Hamiltonian.
+
+This shows the general `AnsatzBase` + `Vqe` API (not tied to QAOA): subclass
+`AnsatzBase`, implement `get_circuit(params)`, and let `Vqe` optimize the
+parameters with PyTorch autograd to minimize <psi|H|psi>.
+
+For H = a*Z + b*X, the exact ground-state energy is -sqrt(a**2 + b**2),
+which this script checks the VQE result against.
+"""
+import math
+
+import torch
+
+from blueqat import Circuit
+from blueqat.utils import AnsatzBase, Vqe, X, Z
+
+
+class SingleQubitAnsatz(AnsatzBase):
+    """A generic single-qubit ansatz: an RY rotation followed by an RZ
+    rotation can reach any point on the Bloch sphere (up to global phase)."""
+
+    def get_circuit(self, params: torch.Tensor) -> Circuit:
+        return Circuit(1).ry(params[0])[0].rz(params[1])[0]
+
+
+if __name__ == "__main__":
+    print("VQE ground-state search")
+    print("=" * 50)
+
+    a, b = 0.5, 0.8
+    hamiltonian = (a * Z[0] + b * X[0]).simplify()
+    print(f"Hamiltonian: {hamiltonian}")
+
+    ansatz = SingleQubitAnsatz(hamiltonian, n_params=2)
+    vqe = Vqe(ansatz)
+    result = vqe.run(max_iter=300)
+
+    found_energy = result.circuit.run(hamiltonian=hamiltonian).item()
+    exact_energy = -math.sqrt(a ** 2 + b ** 2)
+
+    print(f"Optimized parameters: {result.params}")
+    print(f"VQE energy:   {found_energy:.6f}")
+    print(f"Exact energy: {exact_energy:.6f}")


### PR DESCRIPTION
## Summary
- Updated README to match the current PyTorch-based SDK (blueqat.pauli/blueqat.vqe were removed and replaced by blueqat.utils; documents the statevector/tensornet backend split, large-scale circuits, reset, measurement keys, ancilla qubits, from_qasm, and the draw_tn backend). Every snippet was run to confirm it works.
- Fixed both examples/maxcut_qaoa.py and examples/numpartition_qaoa.py, which failed at import (blueqat.pauli, blueqat.vqe no longer exist) and used unsupported Expr ** 2. Rewrote both against the current Vqe/QaoaAnsatz API.
- Added examples/bell_state.py (circuit basics) and examples/vqe_ground_state.py (general AnsatzBase + Vqe usage, not tied to QAOA), since the examples folder previously only had QAOA applications.

## Test plan
- [x] Verified against a fresh clone of blueqat/blueqatSDK:master in a clean venv (not just the local worktree)
- [x] All 4 examples run end-to-end with sensible output
- [x] `pytest tests/` — 1357 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)