### PR TITLE
fix: repair Y-observable/time-evolution sign bugs; add standard tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ https://github.com/Blueqat/Blueqat-tutorials
 ### Examples
 Runnable scripts in [`examples/`](examples/):
 - `bell_state.py` -- circuit basics: statevector, single amplitude, shot sampling
+- `teleportation.py` -- quantum teleportation, coherent and measured versions
+- `grover_search.py` -- Grover's search over 8 items with oracle + diffusion
+- `qft.py` -- Quantum Fourier Transform vs. the DFT matrix, period readout
 - `vqe_ground_state.py` -- VQE with a custom `AnsatzBase` (not tied to QAOA)
 - `maxcut_qaoa.py` -- QAOA for the graph Max-Cut problem
 - `numpartition_qaoa.py` -- QAOA for number partitioning

--- a/blueqat/backends/qasm_output_backend.py
+++ b/blueqat/backends/qasm_output_backend.py
@@ -48,6 +48,8 @@ class QasmOutputBackend(Backend):
     gate_h = _one_qubit_gate_noargs
     gate_t = _one_qubit_gate_noargs
     gate_s = _one_qubit_gate_noargs
+    gate_sx = _one_qubit_gate_noargs
+    gate_sxdg = _one_qubit_gate_noargs
 
     def _two_qubit_gate_noargs(self, gate, ctx):
         for control, target in gate.control_target_iter(ctx[1]):
@@ -102,6 +104,30 @@ class QasmOutputBackend(Backend):
     def gate_cphase(self, gate, ctx):
         for c, t in gate.control_target_iter(ctx[1]):
             ctx[0].append(f"cp({gate.theta}) q[{c}],q[{t}];")
+        return ctx
+
+    def _two_qubit_gate_args_theta(self, gate, ctx):
+        for c, t in gate.control_target_iter(ctx[1]):
+            ctx[0].append(f"{gate.lowername}({gate.theta}) q[{c}],q[{t}];")
+        return ctx
+
+    gate_crx = _two_qubit_gate_args_theta
+    gate_cry = _two_qubit_gate_args_theta
+    gate_crz = _two_qubit_gate_args_theta
+    gate_rxx = _two_qubit_gate_args_theta
+    gate_ryy = _two_qubit_gate_args_theta
+    gate_rzz = _two_qubit_gate_args_theta
+
+    def gate_zz(self, gate, ctx):
+        # ZZ = diag(1, i, i, 1) = e^{i pi/4} * rzz(pi/2); QASM 2.0 can't express
+        # the global phase, so it's noted and dropped (same policy as gate_u).
+        for c, t in gate.control_target_iter(ctx[1]):
+            ctx[0].append(f"rzz(pi/2) q[{c}],q[{t}]; // global phase e^(i*pi/4) is ignored.")
+        return ctx
+
+    def gate_zzdg(self, gate, ctx):
+        for c, t in gate.control_target_iter(ctx[1]):
+            ctx[0].append(f"rzz(-pi/2) q[{c}],q[{t}]; // global phase e^(-i*pi/4) is ignored.")
         return ctx
 
     def _three_qubit_gate_noargs(self, gate, ctx):

--- a/blueqat/circuit.py
+++ b/blueqat/circuit.py
@@ -112,16 +112,20 @@ class Circuit:
         return copied
 
     def dagger(self, ignore_measurement: bool = False) -> 'Circuit':
-        """Make Hermitian conjugate of the circuit."""
+        """Make Hermitian conjugate of the circuit.
+
+        If the circuit contains measurement or reset (which have no Hermitian
+        conjugate), ValueError is raised, unless `ignore_measurement` is True,
+        in which case those operations are simply dropped."""
         ops = []
         for g in reversed(self.ops):
-            try:
-                ops.append(g.dagger())
-            except ValueError:
-                if not ignore_measurement:
-                    raise ValueError(
-                        'Cannot make the Hermitian conjugate of this circuit because '
-                        'the circuit contains measurement.')
+            if not hasattr(g, 'dagger'):
+                if ignore_measurement:
+                    continue
+                raise ValueError(
+                    'Cannot make the Hermitian conjugate of this circuit because '
+                    f'the circuit contains a non-invertible operation `{g.lowername}`.')
+            ops.append(g.dagger())
 
         copied = Circuit(self.n_qubits, ops)
         return copied

--- a/blueqat/circuit_funcs/flatten.py
+++ b/blueqat/circuit_funcs/flatten.py
@@ -54,7 +54,7 @@ def flatten(c: Circuit) -> Circuit:
         elif isinstance(op, g.Measurement):
             if op.key is None:
                 ops.extend([
-                    op.create(t, op.params, None) 
+                    op.create(t, op.params, None)
                     for t in op.target_iter(n_qubits)
                 ])
             else:
@@ -64,10 +64,14 @@ def flatten(c: Circuit) -> Circuit:
                 ops.append(
                     op.create(
                         tuple(t for t in op.target_iter(n_qubits)),
-                        op.params, 
+                        op.params,
                         options
                     )
                 )
+        elif isinstance(op, g.Gate):
+            # 3量子ビット以上のゲート (ccx/ccz/cswap 等)。これらの targets は
+            # スライス不可の明示的なタプルなので、そのまま新しい回路へ移せばよい。
+            ops.append(op.create(tuple(op.targets), op.params, None))
         else:
             raise ValueError(f"Cannot process operation {op.lowername}.")
             

--- a/blueqat/circuit_funcs/qasm_parser.py
+++ b/blueqat/circuit_funcs/qasm_parser.py
@@ -40,7 +40,9 @@ _GATES = {
     # 1-arg 2-qubit
     'cp': ('cphase', 1), 'cu1': ('cphase', 1),
     'crx': ('crx', 1), 'cry': ('cry', 1), 'crz': ('crz', 1),
-    'rxx': ('rxx', 1), 'ryy': ('ryy', 1), 'rzz': ('rzz', 1), 'zz': ('zz', 1),
+    'rxx': ('rxx', 1), 'ryy': ('ryy', 1), 'rzz': ('rzz', 1),
+    # blueqat's zz gate is the fixed diag(1, i, i, 1) -- it takes no angle
+    'zz': ('zz', 0),
     # 4-arg 2-qubit
     'cu': ('cu', 4),
     # no-arg 3-qubit

--- a/blueqat/gate.py
+++ b/blueqat/gate.py
@@ -317,6 +317,8 @@ class SGate(OneQubitGate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'SGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -336,6 +338,8 @@ class SDagGate(OneQubitGate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'SDagGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -355,6 +359,8 @@ class SXGate(OneQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'SXGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -370,6 +376,8 @@ class SXDagGate(OneQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'SXDagGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -385,6 +393,8 @@ class TGate(OneQubitGate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'TGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -407,6 +417,8 @@ class TDagGate(OneQubitGate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'TDagGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -429,6 +441,8 @@ class ToffoliGate(Gate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'ToffoliGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -491,6 +505,8 @@ class XGate(OneQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'XGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -506,6 +522,8 @@ class YGate(OneQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'YGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -521,6 +539,8 @@ class ZGate(OneQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'ZGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -540,6 +560,8 @@ class CCZGate(Gate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'CCZGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def fallback(self, n_qubits):
@@ -565,6 +587,8 @@ class CHGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'CHGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -696,6 +720,8 @@ class CSwapGate(Gate, IFallbackOperation):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'CSwapGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -759,6 +785,8 @@ class CXGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'CXGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -779,6 +807,8 @@ class CYGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'CYGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -799,6 +829,8 @@ class CZGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'CZGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -903,6 +935,8 @@ class SwapGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'SwapGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def matrix(self):
@@ -923,6 +957,8 @@ class ZZGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'ZZGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):
@@ -943,6 +979,8 @@ class ZZDagGate(TwoQubitGate):
 
     @classmethod
     def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'ZZDagGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
         return cls(targets)
 
     def dagger(self):

--- a/blueqat/macros/__init__.py
+++ b/blueqat/macros/__init__.py
@@ -27,20 +27,18 @@ from blueqat.gate import UGate
 
 @circuitmacro
 def draw(c: Circuit, **kwargs) -> Any:
-    """Draw the circuit. This function requires Qiskit."""
-    return c.run(backend='ibmq', returns="draw", **kwargs)
+    """Draw the circuit with the built-in matplotlib-based drawer."""
+    return c.run(backend='draw', **kwargs)
 
 
 @circuitmacro
-def margolus(c: Circuit, c0: int, c1: int) -> Circuit:
+def margolus(c: Circuit, c0: int, c1: int, t: int) -> Circuit:
     """Simplified Toffoli gate implementation by Margolus.
 
     This gate is also as know as relative Toffoli gate.
     It's almost as same as Toffoli gate, but only relative phases are different.
     Refer https://arxiv.org/abs/quant-ph/0312225v1 for details.
     (Remarks: It's also described in Nielsen & Chuang, Exercise 4.26.)"""
-    # 注: 元コードに変数 t の定義がない、あるいは c1, c0 などの使われ方に
-    # 依存する部分がありますが、提示されたロジックをそのまま維持しています。
     c.ry(math.pi * 0.25)[t].cx[c1, t].ry(math.pi * 0.25)[t].cx[c0, t]
     c.ry(math.pi * -0.25)[t].cx[c1, t].ry(math.pi * -0.25)[t]
     return c

--- a/blueqat/utils.py
+++ b/blueqat/utils.py
@@ -264,24 +264,39 @@ class Term(_TermTuple):
     def is_commutable_with(self, other: Any) -> bool: return is_commutable(self, other)
 
     def get_time_evolution(self) -> Any:
+        """Returns a function `f(circuit, t)` appending exp(-i t P) to `circuit`,
+        where P = coeff * (this term's Pauli product). Requires a real coefficient
+        (a complex one would make the "evolution" non-unitary)."""
         term = self.simplify()
         coeff, ops = term.coeff, term.ops
+        if isinstance(coeff, complex):
+            if coeff.imag != 0:
+                raise ValueError("Cannot make time evolution of complex coefficient.")
+            coeff = coeff.real
+        elif isinstance(coeff, torch.Tensor) and torch.is_complex(coeff):
+            if coeff.imag != 0:
+                raise ValueError("Cannot make time evolution of complex coefficient.")
+            coeff = coeff.real
 
         def append_to_circuit(circuit: Any, t: float) -> None:
             if not ops: return
+            # Basis change into Z: H X H = Z, and RX(+pi/2) Y RX(-pi/2) = Z
+            # (RX(-pi/2) would give -Z, silently flipping the sign for Y terms).
             for op in ops:
                 if op.op == "X": circuit.h[op.n]
-                elif op.op == "Y": circuit.rx(-half_pi)[op.n]
+                elif op.op == "Y": circuit.rx(half_pi)[op.n]
             for i in range(1, len(ops)):
                 circuit.cx[ops[i - 1].n, ops[i].n]
-            
-            circuit.rz(-2 * coeff * t)[ops[-1].n]
-            
+
+            # exp(-i theta P) with P a Pauli product == RZ(2 theta) on the parity
+            # qubit (rz(phi) = diag(e^{-i phi/2}, e^{i phi/2})).
+            circuit.rz(2 * coeff * t)[ops[-1].n]
+
             for i in range(len(ops) - 1, 0, -1):
                 circuit.cx[ops[i - 1].n, ops[i].n]
             for op in ops:
                 if op.op == "X": circuit.h[op.n]
-                elif op.op == "Y": circuit.rx(half_pi)[op.n]
+                elif op.op == "Y": circuit.rx(-half_pi)[op.n]
 
         return append_to_circuit
 
@@ -603,11 +618,14 @@ class AnsatzBase:
             c = Circuit(n_qubits)
             c.ops = list(circuit.ops)
 
+            # Rotate each measured operator into the Z basis: H X H = Z and
+            # RX(+pi/2) Y RX(-pi/2) = Z. Using RX(-pi/2) here would measure -Y,
+            # flipping the sign of every term containing an odd number of Y's.
             for op in meas.ops:
                 if op.op == "X":
                     c.h[op.n]
                 elif op.op == "Y":
-                    c.rx(torch.tensor(-torch.pi / 2, dtype=torch.float64))[op.n]
+                    c.rx(torch.tensor(torch.pi / 2, dtype=torch.float64))[op.n]
 
             # 4. サンプラーが返す (測定qubitごとのbit tuple -> 確率) を実際に消費し、
             #    各qubitの1ビットのパリティで符号を決めて集計する

--- a/examples/grover_search.py
+++ b/examples/grover_search.py
@@ -1,0 +1,61 @@
+"""Grover's search: find a marked item in an unsorted database of 8 entries.
+
+A classical search over N unsorted items needs O(N) queries; Grover's algorithm
+needs only O(sqrt(N)). Each iteration applies the "oracle" (which flips the
+phase of the marked state) and the "diffusion" operator (inversion about the
+mean), rotating the state a little closer to the marked item.
+
+For N = 8 items (3 qubits), the optimal number of iterations is
+round(pi/4 * sqrt(8)) = 2, giving a success probability of about 94.5%.
+"""
+import math
+from collections import Counter
+
+from blueqat import Circuit
+import blueqat.macros  # noqa: F401  -- registers the mcz_gray macro
+
+
+N_QUBITS = 3
+MARKED = "101"  # the bitstring we want to find (qubit 0 is the rightmost bit)
+
+
+def oracle(c: Circuit, marked: str) -> Circuit:
+    """Flip the sign of |marked>. X-conjugation turns the all-ones controlled-Z
+    into a phase flip on exactly the marked bitstring."""
+    zeros = [i for i, b in enumerate(reversed(marked)) if b == "0"]
+    if zeros:
+        c.x[tuple(zeros)]
+    c.mcz_gray(list(range(N_QUBITS - 1)), N_QUBITS - 1)
+    if zeros:
+        c.x[tuple(zeros)]
+    return c
+
+
+def diffusion(c: Circuit) -> Circuit:
+    """Inversion about the mean: H X (controlled-Z on all) X H."""
+    c.h[:].x[:]
+    c.mcz_gray(list(range(N_QUBITS - 1)), N_QUBITS - 1)
+    c.x[:].h[:]
+    return c
+
+
+if __name__ == "__main__":
+    print(f"Grover search for |{MARKED}> among {2**N_QUBITS} items")
+    print("=" * 50)
+
+    n_iterations = round(math.pi / 4 * math.sqrt(2 ** N_QUBITS))
+    c = Circuit(N_QUBITS).h[:]          # uniform superposition
+    for _ in range(n_iterations):
+        oracle(c, MARKED)
+        diffusion(c)
+
+    probs = (c.run().abs() ** 2)
+    p_marked = probs[int(MARKED, 2)].item()
+    print(f"Iterations: {n_iterations}")
+    print(f"P(|{MARKED}>) = {p_marked:.4f}  (theory: {math.sin((2*n_iterations+1)*math.asin(1/math.sqrt(8)))**2:.4f})")
+
+    counts: Counter = c.m[:].shots(1000)
+    print(f"1000 shots: {dict(sorted(counts.items(), key=lambda kv: -kv[1]))}")
+    assert p_marked > 0.9, "Grover should amplify the marked state above 90%"
+    assert counts.most_common(1)[0][0] == MARKED
+    print("OK: the marked item was found with high probability.")

--- a/examples/numpartition_qaoa.py
+++ b/examples/numpartition_qaoa.py
@@ -35,11 +35,11 @@ if __name__ == "__main__":
     print(f"Numbers: {nums} (total: {sum(nums)})")
 
     hamiltonian = numpartition_hamiltonian(nums)
-    vqe = Vqe(QaoaAnsatz(hamiltonian, step=3))
+    vqe = Vqe(QaoaAnsatz(hamiltonian, step=4))
     result = vqe.run(max_iter=500)
 
     # Look at the top candidates and keep the best-balanced one.
-    candidates = result.most_common(5)
+    candidates = result.most_common(10)
     best_bits, best_diff = None, None
     for bits, _ in candidates:
         group0 = [x for x, b in zip(nums, bits) if b == 0]
@@ -54,3 +54,5 @@ if __name__ == "__main__":
     print(f"Group 0 (sum={sum(group0)}): {group0}")
     print(f"Group 1 (sum={sum(group1)}): {group1}")
     print(f"Difference: {best_diff}")
+    # The total (37) is odd, so a difference of 1 is the best possible.
+    assert best_diff == 1, f"expected the optimal partition (diff 1), got {best_diff}"

--- a/examples/qft.py
+++ b/examples/qft.py
@@ -1,0 +1,57 @@
+"""Quantum Fourier Transform: the workhorse behind phase estimation and Shor.
+
+The QFT maps |j> to (1/sqrt(N)) sum_k exp(2 pi i jk / N) |k> -- a discrete
+Fourier transform of the amplitude vector, done in O(n^2) gates instead of the
+classical O(N log N). This script builds the textbook H + controlled-phase
+ladder, checks it against the DFT matrix, and uses it to read out the period
+of a simple periodic state.
+"""
+import cmath
+import math
+
+import numpy as np
+
+from blueqat import Circuit
+from blueqat.circuit_funcs.circuit_to_unitary import circuit_to_unitary
+
+
+def qft(n: int) -> Circuit:
+    """Textbook QFT circuit on n qubits (qubit 0 = least-significant bit)."""
+    c = Circuit(n)
+    for i in reversed(range(n)):
+        c.h[i]
+        for k in range(i):
+            c.cphase(math.pi / 2 ** (i - k))[k, i]
+    for i in range(n // 2):          # bit-reversal swaps
+        c.swap[i, n - 1 - i]
+    return c
+
+
+if __name__ == "__main__":
+    n = 3
+    dim = 2 ** n
+    print(f"Quantum Fourier Transform on {n} qubits")
+    print("=" * 50)
+
+    # 1. The circuit's unitary must equal the DFT matrix.
+    omega = cmath.exp(2j * math.pi / dim)
+    dft = np.array([[omega ** (j * k) for j in range(dim)]
+                    for k in range(dim)]) / math.sqrt(dim)
+    u = circuit_to_unitary(qft(n))
+    print(f"Matches DFT matrix: {np.allclose(u, dft, atol=1e-8)}")
+    assert np.allclose(u, dft, atol=1e-8)
+
+    # 2. QFT of a period-2 state (|0> + |2> + |4> + |6>)/2 concentrates all
+    #    probability on multiples of N/period = 4, i.e. |0> and |4>.
+    initial = np.zeros(dim, dtype=complex)
+    initial[::2] = 0.5
+    state = qft(n).run(initial=initial)
+    probs = (state.abs() ** 2).numpy().round(6)
+    print(f"QFT of period-2 state, P(k): {dict((k, p) for k, p in enumerate(probs) if p > 1e-9)}")
+    assert abs(probs[0] - 0.5) < 1e-8 and abs(probs[4] - 0.5) < 1e-8
+
+    # 3. QFT followed by its dagger is the identity.
+    c = qft(n)
+    roundtrip = (c + c.dagger()).run(initial=initial)
+    assert np.allclose(roundtrip.numpy(), initial, atol=1e-8)
+    print("OK: unitary check, period readout, and dagger round-trip all pass.")

--- a/examples/teleportation.py
+++ b/examples/teleportation.py
@@ -1,0 +1,66 @@
+"""Quantum teleportation: move a qubit state using entanglement.
+
+Alice holds an unknown state |psi> on qubit 0 and shares a Bell pair with Bob
+(qubits 1 and 2). After Alice's Bell-basis rotation, Bob applies corrections
+and ends up holding |psi> exactly -- no matter what it was. Here the usual
+"measure, then send 2 classical bits" step is replaced by coherent CX/CZ
+corrections, which lets us verify the transfer deterministically on the
+statevector. A shot-based run with real mid-circuit measurement follows.
+"""
+import math
+import random
+
+import numpy as np
+
+from blueqat import Circuit
+
+
+def make_psi(theta: float, phi: float) -> np.ndarray:
+    return np.array([math.cos(theta / 2),
+                     cmath_exp(phi) * math.sin(theta / 2)])
+
+
+def cmath_exp(phi: float) -> complex:
+    return complex(math.cos(phi), math.sin(phi))
+
+
+if __name__ == "__main__":
+    print("Quantum teleportation (qubit 0 -> qubit 2)")
+    print("=" * 50)
+    rng = random.Random(7)
+    theta, phi = rng.uniform(0, math.pi), rng.uniform(0, 2 * math.pi)
+    psi = make_psi(theta, phi)
+    print(f"State to teleport: {psi.round(4)}")
+
+    # --- Coherent version: deterministic, verifiable on the statevector ----
+    c = Circuit(3)
+    c.ry(theta)[0].rz(phi)[0]        # prepare |psi> on qubit 0 (up to phase)
+    c.h[1].cx[1, 2]                  # Bell pair between qubits 1 and 2
+    c.cx[0, 1].h[0]                  # Alice rotates into the Bell basis
+    c.cx[1, 2].cz[0, 2]              # Bob's corrections (coherently controlled)
+
+    state = c.run().numpy()
+    # Expected result: qubits 0 and 1 in |+>, qubit 2 holding |psi>.
+    plus = np.array([1, 1]) / math.sqrt(2)
+    psi_up_to_phase = Circuit(1).ry(theta)[0].rz(phi)[0].run().numpy()
+    expected = np.kron(psi_up_to_phase, np.kron(plus, plus))
+    ok = np.allclose(state, expected, atol=1e-8)
+    print(f"Coherent teleportation exact: {ok}")
+    assert ok
+
+    # --- Measured version: real mid-circuit collapse, statistical check ----
+    # Without classical feed-forward we can still verify the Z-basis statistics:
+    # P(qubit2 = 1) must equal |<1|psi>|^2 = sin^2(theta/2) regardless of
+    # Alice's (discarded) measurement results.
+    shots = 4000
+    c2 = Circuit(3)
+    c2.ry(theta)[0].rz(phi)[0]
+    c2.h[1].cx[1, 2]
+    c2.cx[0, 1].h[0]
+    c2.cx[1, 2].cz[0, 2]
+    c2.m[2]                          # only Bob's qubit is reported
+    counts = c2.shots(shots)
+    p1 = sum(v for k, v in counts.items() if k[0] == "1") / shots
+    print(f"P(qubit2=1) sampled: {p1:.3f}   theory: {math.sin(theta/2)**2:.3f}")
+    assert abs(p1 - math.sin(theta / 2) ** 2) < 0.05
+    print("OK: Bob receives |psi> exactly; sampled statistics agree.")

--- a/tests/test_quantum_standard.py
+++ b/tests/test_quantum_standard.py
@@ -1,0 +1,337 @@
+"""Standard quantum-computing correctness tests, in the style used by other
+quantum SDKs (Qiskit / Cirq): algebraic gate identities, canonical entangled
+states, the QFT against the DFT matrix, coherent teleportation, dagger
+(uncompute) round-trips, cross-backend consistency, Trotterized time evolution
+against the exact matrix exponential, and shot-statistics sanity checks.
+"""
+import cmath
+import math
+import random
+
+import pytest
+import torch
+
+from blueqat import Circuit
+from blueqat.circuit_funcs.circuit_to_unitary import circuit_to_unitary
+from blueqat.utils import X, Y, Z, term_from_chars
+
+import numpy as np
+
+ATOL = 1e-8
+
+MODES = ["statevector", "tensornet"]
+
+
+def _u(c: Circuit) -> np.ndarray:
+    return circuit_to_unitary(c)
+
+
+def _allclose_up_to_global_phase(a: np.ndarray, b: np.ndarray, atol: float = ATOL) -> bool:
+    tr = np.trace(a.conj().T @ b)
+    if abs(tr) < atol:
+        return False
+    phase = tr / abs(tr)
+    return np.allclose(a * phase, b, atol=atol)
+
+
+# --- 1. Algebraic gate identities ------------------------------------------
+
+IDENTITY_CASES = [
+    ("HXH=Z", Circuit(1).h[0].x[0].h[0], Circuit(1).z[0]),
+    ("HZH=X", Circuit(1).h[0].z[0].h[0], Circuit(1).x[0]),
+    ("S^2=Z", Circuit(1).s[0].s[0], Circuit(1).z[0]),
+    ("T^2=S", Circuit(1).t[0].t[0], Circuit(1).s[0]),
+    ("T^4=Z", Circuit(1).t[0].t[0].t[0].t[0], Circuit(1).z[0]),
+    ("SX^2=X", Circuit(1).sx[0].sx[0], Circuit(1).x[0]),
+    ("X^2=I", Circuit(1).x[0].x[0], Circuit(1).i[0]),
+    ("Y^2=I", Circuit(1).y[0].y[0], Circuit(1).i[0]),
+    ("Z^2=I", Circuit(1).z[0].z[0], Circuit(1).i[0]),
+    ("H^2=I", Circuit(1).h[0].h[0], Circuit(1).i[0]),
+    ("S*Sdg=I", Circuit(1).s[0].sdg[0], Circuit(1).i[0]),
+    ("T*Tdg=I", Circuit(1).t[0].tdg[0], Circuit(1).i[0]),
+    ("SX*SXdg=I", Circuit(1).sx[0].sxdg[0], Circuit(1).i[0]),
+    ("CX^2=I", Circuit(2).cx[0, 1].cx[0, 1], Circuit(2).i[0]),
+    ("CZ^2=I", Circuit(2).cz[0, 1].cz[0, 1], Circuit(2).i[0]),
+    ("SWAP^2=I", Circuit(2).swap[0, 1].swap[0, 1], Circuit(2).i[0]),
+    ("CCX^2=I", Circuit(3).ccx[0, 1, 2].ccx[0, 1, 2], Circuit(3).i[0]),
+    # XYZ = iI, so up to global phase it's the identity
+    ("XYZ~I", Circuit(1).z[0].y[0].x[0], Circuit(1).i[0]),
+    # CZ is symmetric in its qubits
+    ("CZ symm", Circuit(2).cz[0, 1], Circuit(2).cz[1, 0]),
+    # CX with H conjugation flips control/target
+    ("HH-CX-HH", Circuit(2).h[0].h[1].cx[0, 1].h[0].h[1], Circuit(2).cx[1, 0]),
+    # SWAP = 3 alternating CX
+    ("SWAP=3CX", Circuit(2).cx[0, 1].cx[1, 0].cx[0, 1], Circuit(2).swap[0, 1]),
+]
+
+
+@pytest.mark.parametrize("case", IDENTITY_CASES, ids=lambda c: c[0])
+def test_gate_identity(case):
+    name, lhs, rhs = case
+    assert _allclose_up_to_global_phase(_u(lhs), _u(rhs)), f"identity {name} violated"
+
+
+def test_euler_decomposition_u_gate():
+    # U(theta, phi, lam) == e^{i alpha} RZ(phi) RY(theta) RZ(lam)
+    theta, phi, lam = 0.7, 1.1, -0.4
+    u = _u(Circuit(1).u(theta, phi, lam)[0])
+    zyz = _u(Circuit(1).rz(lam)[0].ry(theta)[0].rz(phi)[0])
+    assert _allclose_up_to_global_phase(u, zyz)
+
+
+def test_rz_pi_is_z_up_to_phase():
+    assert _allclose_up_to_global_phase(_u(Circuit(1).rz(math.pi)[0]), _u(Circuit(1).z[0]))
+
+
+def test_phase_gate_equals_rz_up_to_phase():
+    theta = 0.9
+    assert _allclose_up_to_global_phase(
+        _u(Circuit(1).phase(theta)[0]), _u(Circuit(1).rz(theta)[0]))
+
+
+# --- 2. Canonical entangled states ------------------------------------------
+
+@pytest.mark.parametrize("mode", MODES)
+def test_bell_state(mode):
+    state = Circuit(2).h[0].cx[0, 1].run(backend=mode)
+    expected = torch.zeros(4, dtype=torch.complex128)
+    expected[0] = expected[3] = 1 / math.sqrt(2)
+    assert torch.allclose(state, expected, atol=ATOL)
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_ghz_state(mode):
+    n = 5
+    c = Circuit(n).h[0]
+    for i in range(n - 1):
+        c.cx[i, i + 1]
+    state = c.run(backend=mode)
+    expected = torch.zeros(2 ** n, dtype=torch.complex128)
+    expected[0] = expected[-1] = 1 / math.sqrt(2)
+    assert torch.allclose(state, expected, atol=ATOL)
+
+
+def test_w_state_3qubit():
+    # W = (|001> + |010> + |100>)/sqrt(3), built with RY + controlled ops.
+    theta = 2 * math.acos(1 / math.sqrt(3))
+    c = Circuit(3)
+    c.ry(theta)[0]
+    c.ch[0, 1]
+    c.cx[1, 2].cx[0, 1].x[0]
+    state = c.run().detach().numpy()
+    expected = np.zeros(8, dtype=complex)
+    expected[0b001] = expected[0b010] = expected[0b100] = 1 / math.sqrt(3)
+    assert np.allclose(np.abs(state), np.abs(expected), atol=ATOL)
+
+
+# --- 3. QFT vs the DFT matrix ------------------------------------------------
+
+def _qft_circuit(n: int) -> Circuit:
+    c = Circuit(n)
+    for i in reversed(range(n)):
+        c.h[i]
+        for k in range(i):
+            c.cphase(math.pi / 2 ** (i - k))[k, i]
+    for i in range(n // 2):
+        c.swap[i, n - 1 - i]
+    return c
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4])
+def test_qft_matches_dft_matrix(n):
+    dim = 2 ** n
+    omega = cmath.exp(2j * math.pi / dim)
+    dft = np.array([[omega ** (j * k) for j in range(dim)] for k in range(dim)]) / math.sqrt(dim)
+    assert np.allclose(_u(_qft_circuit(n)), dft, atol=ATOL)
+
+
+def test_qft_dagger_is_inverse():
+    c = _qft_circuit(3)
+    u = _u(c + c.dagger())
+    assert np.allclose(u, np.eye(8), atol=ATOL)
+
+
+# --- 4. Coherent quantum teleportation ---------------------------------------
+
+@pytest.mark.parametrize("mode", MODES)
+def test_coherent_teleportation(mode):
+    # Teleport a random 1-qubit state from qubit 0 to qubit 2, replacing the
+    # usual measurement + classical corrections with coherent CX/CZ corrections.
+    rng = random.Random(42)
+    alpha_angle, phase_angle = rng.uniform(0, math.pi), rng.uniform(0, 2 * math.pi)
+
+    c = Circuit(3)
+    c.ry(alpha_angle)[0].rz(phase_angle)[0]     # prepare |psi> on q0
+    psi = Circuit(1).ry(alpha_angle)[0].rz(phase_angle)[0].run().detach().numpy()
+
+    c.h[1].cx[1, 2]                             # Bell pair on q1, q2
+    c.cx[0, 1].h[0]                             # Bell measurement basis rotation
+    c.cx[1, 2].cz[0, 2]                         # coherent corrections
+
+    state = c.run(backend=mode).detach().numpy()
+    # Expected: |+>_0 |+>_1 |psi>_2 with qubit 0 the least-significant bit.
+    plus = np.array([1, 1]) / math.sqrt(2)
+    expected = np.kron(psi, np.kron(plus, plus))
+    assert np.allclose(state, expected, atol=ATOL)
+
+
+# --- 5. Dagger (uncompute) round-trips ---------------------------------------
+
+def _random_circuit(n_qubits: int, depth: int, seed: int) -> Circuit:
+    rng = random.Random(seed)
+    c = Circuit(n_qubits)
+    one_q = ['h', 'x', 'y', 'z', 's', 't', 'sx']
+    rot = ['rx', 'ry', 'rz', 'phase']
+    for _ in range(depth):
+        kind = rng.random()
+        q = rng.randrange(n_qubits)
+        if kind < 0.35:
+            getattr(c, rng.choice(one_q))[q]
+        elif kind < 0.65:
+            getattr(c, rng.choice(rot))(rng.uniform(0, 2 * math.pi))[q]
+        else:
+            q2 = rng.choice([i for i in range(n_qubits) if i != q])
+            name = rng.choice(['cx', 'cz', 'swap', 'crz', 'cphase'])
+            if name in ('crz', 'cphase'):
+                getattr(c, name)(rng.uniform(0, 2 * math.pi))[q, q2]
+            else:
+                getattr(c, name)[q, q2]
+    return c
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3])
+def test_dagger_uncomputes_random_circuit(seed):
+    c = _random_circuit(4, 25, seed)
+    state = (c + c.dagger()).run()
+    expected = torch.zeros(16, dtype=torch.complex128)
+    expected[0] = 1.0
+    assert torch.allclose(state, expected, atol=1e-7)
+
+
+def test_dagger_rejects_measurement():
+    with pytest.raises(ValueError):
+        Circuit(1).h[0].m[0].dagger()
+
+
+def test_dagger_ignore_measurement_drops_it():
+    c = Circuit(1).h[0].m[0].dagger(ignore_measurement=True)
+    assert len(c.ops) == 1 and c.ops[0].lowername == 'h'
+
+
+# --- 6. Cross-backend consistency --------------------------------------------
+
+@pytest.mark.parametrize("seed", [10, 11, 12])
+def test_statevector_and_tensornet_agree(seed):
+    c = _random_circuit(4, 30, seed)
+    sv = c.run(backend="statevector")
+    tn = c.run(backend="tensornet")
+    assert torch.allclose(sv, tn, atol=1e-8)
+
+
+# --- 7. Trotterized time evolution vs exact matrix exponential ----------------
+
+@pytest.mark.parametrize("chars,coeff,t", [
+    ("Z", 0.7, 0.9),
+    ("X", -1.3, 0.4),
+    ("Y", 0.5, 1.7),
+    ("XZ", 0.8, 0.6),
+    ("ZYX", -0.6, 1.1),
+])
+def test_time_evolution_matches_matrix_exponential(chars, coeff, t):
+    # term_from_chars("XZ") = X0*Z1; a single Pauli term's evolution circuit is
+    # exact (no Trotter error), so it must equal expm(-i t H) exactly.
+    term = (coeff * term_from_chars(chars)).simplify()
+    n = len(chars)
+    h_mat = term.to_matrix(n).to(torch.complex128)
+    expected_u = torch.matrix_exp(-1j * t * h_mat).numpy()
+
+    c = Circuit(n)
+    term.get_time_evolution()(c, t)
+    assert _allclose_up_to_global_phase(_u(c), expected_u, atol=1e-7), \
+        "time evolution circuit deviates from expm(-i t H)"
+
+
+def test_time_evolution_rejects_complex_coefficient():
+    with pytest.raises(ValueError):
+        ((1 + 1j) * Z[0]).to_term().get_time_evolution()
+
+
+def test_get_energy_y_observable_sign():
+    # Regression: the sampler-based get_energy used to measure -Y instead of Y
+    # (wrong direction of the RX basis rotation), flipping the sign of every
+    # term with an odd number of Y operators. <Y> on RX(0.9)|0> is -sin(0.9).
+    from blueqat.utils import AnsatzBase, non_sampling_sampler
+
+    class OneParamAnsatz(AnsatzBase):
+        def get_circuit(self, params):
+            return Circuit(1).rx(params[0])[0]
+
+    ansatz = OneParamAnsatz((1.0 * Y[0]).to_expr().simplify(), 1)
+    ansatz.make_sparse(sparse=False)
+    c = ansatz.get_circuit(torch.tensor([0.9], dtype=torch.float64))
+    e_sampled = ansatz.get_energy(c, non_sampling_sampler).item()
+    e_exact = ansatz.get_energy_sparse(c).item()
+    assert e_sampled == pytest.approx(-math.sin(0.9), abs=1e-8)
+    assert e_sampled == pytest.approx(e_exact, abs=1e-8)
+
+
+# --- 8. Shot statistics sanity -------------------------------------------------
+
+@pytest.mark.parametrize("mode", MODES)
+def test_bell_shot_statistics(mode):
+    torch.manual_seed(1234)
+    shots = 10000
+    counts = Circuit(2).h[0].cx[0, 1].shots(shots, backend=mode)
+    assert set(counts) <= {"00", "11"}
+    assert sum(counts.values()) == shots
+    # ~50/50 with generous 5-sigma bounds (sigma = sqrt(N)/2 = 50)
+    assert abs(counts["00"] - shots / 2) < 5 * math.sqrt(shots) / 2 + 1
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_deterministic_shots(mode):
+    counts = Circuit(2).x[0].shots(100, backend=mode)
+    assert counts == {"01": 100}
+
+
+# --- 9. Regression tests for audit fixes ---------------------------------------
+
+def test_fixed_gates_reject_bogus_params():
+    for build in [
+        lambda: Circuit(1).x(0.5)[0],
+        lambda: Circuit(1).h(0.5)[0],
+        lambda: Circuit(2).cx(0.5)[0, 1],
+        lambda: Circuit(2).zz(0.5)[0, 1],
+        lambda: Circuit(2).swap(0.5)[0, 1],
+        lambda: Circuit(3).ccx(0.5)[0, 1, 2],
+    ]:
+        with pytest.raises(ValueError):
+            build()
+
+
+def test_margolus_is_relative_phase_toffoli():
+    import blueqat.macros  # noqa: F401  (registers the macro)
+    u_marg = _u(Circuit(3).margolus(0, 1, 2))
+    u_ccx = _u(Circuit(3).ccx[0, 1, 2])
+    # Same absolute amplitudes as Toffoli (differs only in relative phases)...
+    assert np.allclose(np.abs(u_marg), np.abs(u_ccx), atol=ATOL)
+    # ...and still unitary.
+    assert np.allclose(u_marg @ u_marg.conj().T, np.eye(8), atol=ATOL)
+
+
+def test_json_roundtrip_three_qubit_gates():
+    from blueqat.circuit_funcs.json_serializer import serialize, deserialize
+    c = Circuit(3).h[0].ccx[0, 1, 2].cswap[0, 1, 2].ccz[0, 1, 2]
+    c2 = deserialize(serialize(c))
+    assert torch.allclose(c.run(), c2.run(), atol=ATOL)
+
+
+def test_qasm_roundtrip_extended_gate_set():
+    from blueqat.circuit_funcs.qasm_parser import from_qasm
+    c = (Circuit(2).sx[0].sxdg[1].crx(0.5)[0, 1].cry(0.6)[0, 1].crz(0.7)[0, 1]
+         .rxx(0.3)[0, 1].ryy(0.4)[0, 1].rzz(0.5)[0, 1].zz[0, 1])
+    c2 = from_qasm(c.to_qasm())
+    v1 = c.run().detach().numpy()
+    v2 = c2.run().detach().numpy()
+    # zz -> rzz(pi/2) drops a global phase, so compare via fidelity.
+    assert abs(np.vdot(v1, v2)) == pytest.approx(1.0, abs=1e-8)


### PR DESCRIPTION
## Summary
SDK全体の監査で発見した9件のバグ修正と、テスト・examplesの品質向上。

**物理的に結果が間違う重大バグ:**
- `get_time_evolution()` が標準の exp(-itP) ではなく exp(+itP) を実装していた
- `get_energy()` / `get_time_evolution()` のY基底変換が RX(-π/2)（Y→-Z）になっており、Yを奇数個含む項の期待値・時間発展の符号がすべて反転していた

**クラッシュ系:**
- `margolus` マクロの NameError（引数欠落）
- `draw` マクロが存在しない ibmq バックエンドを呼んでいた
- `flatten()`/JSONシリアライズが3量子ビットゲート（ccx/ccz/cswap）でクラッシュ
- `to_qasm()` が sx/sxdg/crx/cry/crz/rxx/ryy/rzz/zz でクラッシュ
- `Circuit.dagger()` の測定処理（AttributeError / ignore_measurement 無効）

**サイレント誤動作:**
- 19個の固定ゲートが `x(0.5)[0]` のような誤パラメータを黙って受理（QASMパーサの zz 角度の黙殺もこれで顕在化・修正）
- 複素係数の時間発展に明確な ValueError を追加

**テスト (+59件、計1503件):** ゲート恒等式、Euler分解、Bell/GHZ/W状態、QFT vs DFT行列、テレポーテーション、dagger逆算、クロスバックエンド一致、時間発展 vs expm(-itH)、ショット統計、全修正の回帰テスト

**Examples (4→7本):** grover_search.py / qft.py / teleportation.py を追加、numpartition_qaoa.py に最適解のassertを追加、README更新

## Test plan
- [x] `pytest tests/ -q` 全1503件通過
- [x] examples/ 全7本の実行確認