### PR TITLE
feat: SDK-parity features (probs/expect/depth/iswap/barrier) and cloud API-key groundwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ from blueqat.utils import Z
 hamiltonian = 1*Z[0]+1*Z[1]
 Circuit(4).x[:].run(hamiltonian=hamiltonian)
 # => -2.0
+
+# Or the equivalent convenience method (differentiable):
+Circuit(4).x[:].expect(hamiltonian)
+```
+
+### Probabilities, depth and gate counts
+```python
+Circuit(2).h[0].cx[0, 1].probs()        # measurement probabilities (differentiable)
+Circuit(2).h[0].cx[0, 1].probs([1])     # marginal on selected qubits
+Circuit(2).h[0].cx[0, 1].depth()        # => 2
+Circuit(2).h[0].cx[0, 1].count_ops()    # => Counter({'h': 1, 'cx': 1})
+```
+
+### Cloud access (API key groundwork)
+```python
+import blueqat.cloud as cloud
+cloud.save_api_key("YOUR_API_KEY")   # stored in ~/.blueqat/config.json (0600)
+# or: export BLUEQAT_API_KEY=...    # environment variable takes priority
+
+import blueqat.cloud                 # registers the 'cloud' backend
+# Circuit(2).h[0].cx[0, 1].m[:].run(backend='cloud', shots=100)
+# (submits the JSON-serialized circuit once the public endpoint is live)
 ```
 
 ### Blueqat to/from QASM

--- a/blueqat/backends/draw_backend.py
+++ b/blueqat/backends/draw_backend.py
@@ -217,7 +217,7 @@ class DrawCircuit(Backend):
         time_adjust = time%30
         for idx in gate.target_iter(ctx[1]):
             ypos_adjust = idx * 1.5 + math.floor(time/30)*(ctx[1]+1)*1.5
-            qlist[idx].append({'num': flg, 'gate': gate.lowername.upper(), 'angle': round(gate.theta, 2), 'xpos': time_adjust, 'ypos': ypos_adjust, 'type': 'gate'})
+            qlist[idx].append({'num': flg, 'gate': gate.lowername.upper(), 'angle': round(float(gate.theta), 2), 'xpos': time_adjust, 'ypos': ypos_adjust, 'type': 'gate'})
             flg += 1
         ctx[2].append(flg)
         ctx[3].append(time+1)
@@ -287,7 +287,7 @@ class DrawCircuit(Backend):
 
         time_adjust = time%30
         for control, target in gate.control_target_iter(ctx[1]):
-            qlist[target].append({'num': flg, 'gate': 'RZ', 'angle': round(gate.theta, 2), 'xpos': time_adjust, 'ypos': target * 1.5 + math.floor(time/30)*(ctx[1]+1)*1.5, 'type': 'gate'})
+            qlist[target].append({'num': flg, 'gate': 'RZ', 'angle': round(float(gate.theta), 2), 'xpos': time_adjust, 'ypos': target * 1.5 + math.floor(time/30)*(ctx[1]+1)*1.5, 'type': 'gate'})
             flg += 1
             qlist[control].append({'num': flg, 'gate': 'CRZ', 'angle': '', 'xpos': time_adjust, 'ypos': control * 1.5 + math.floor(time/30)*(ctx[1]+1)*1.5, 'type': 'gate'})
             flg += 1

--- a/blueqat/backends/flexible_circuit_composer.py
+++ b/blueqat/backends/flexible_circuit_composer.py
@@ -7,6 +7,16 @@ class FlexibleCircuitComposer:
         """
         self.max_block_size = max_block_size
 
+    def run(self, ops, n_qubits=None, max_block_size=None, **kwargs):
+        """Backend entry point so `Circuit.run(backend='composer')` works.
+        Returns the composed block list from `compose`."""
+        if max_block_size is not None:
+            self.max_block_size = max_block_size
+        return self.compose(ops, n_qubits)
+
+    def copy(self):
+        return FlexibleCircuitComposer(self.max_block_size)
+
     def compose(self, ops, n_qubits=None):
         """量子回路のゲート列（ops）をスキャンし、指定サイズ以下のブロックに集約する"""
         composed_blocks = []

--- a/blueqat/backends/qasm_output_backend.py
+++ b/blueqat/backends/qasm_output_backend.py
@@ -144,3 +144,8 @@ class QasmOutputBackend(Backend):
         return ctx
 
     gate_reset = _one_qubit_gate_noargs
+
+    def gate_barrier(self, gate, ctx):
+        qubits = ",".join(f"q[{idx}]" for idx in gate.target_iter(ctx[1]))
+        ctx[0].append(f"barrier {qubits};")
+        return ctx

--- a/blueqat/circuit.py
+++ b/blueqat/circuit.py
@@ -187,6 +187,82 @@ class Circuit:
         vec, cnt = backend.run(self.ops, self.n_qubits, shots=1, returns='statevector_and_shots', **kwargs)
         return vec, next(iter(cnt))
 
+    def _expanded_applications(self):
+        """Yield (lowername, qubit-tuple) for each atomic gate application,
+        expanding slices/multi-targets the same way the backends do."""
+        from .gate import (Barrier, Gate, Measurement, OneQubitGate, Reset,
+                           TwoQubitGate)
+        n_qubits = self.n_qubits
+        for op in self.ops:
+            if isinstance(op, Barrier):
+                yield op.lowername, tuple(op.target_iter(n_qubits))
+            elif isinstance(op, (OneQubitGate, Measurement, Reset)):
+                for t in op.target_iter(n_qubits):
+                    yield op.lowername, (t, )
+            elif isinstance(op, TwoQubitGate):
+                for c, t in op.control_target_iter(n_qubits):
+                    yield op.lowername, (c, t)
+            elif isinstance(op, Gate):
+                yield op.lowername, tuple(op.targets)
+            else:
+                yield op.lowername, tuple(op.target_iter(n_qubits))
+
+    def depth(self) -> int:
+        """Circuit depth: length of the longest gate sequence on any qubit path,
+        counting each expanded gate application (as in Qiskit). Barriers don't
+        add depth."""
+        depths = [0] * self.n_qubits
+        for name, qubits in self._expanded_applications():
+            if name == 'barrier' or not qubits:
+                continue
+            d = max(depths[q] for q in qubits) + 1
+            for q in qubits:
+                depths[q] = d
+        return max(depths, default=0)
+
+    def count_ops(self) -> typing.Counter[str]:
+        """Count expanded gate applications by name (as in Qiskit's count_ops)."""
+        import collections
+        return collections.Counter(name for name, _ in self._expanded_applications())
+
+    def probs(self, qubits: Optional[typing.Sequence[int]] = None,
+              backend: 'BackendUnion' = None, **kwargs) -> torch.Tensor:
+        """Measurement probabilities of the circuit's final state, optionally
+        marginalized onto `qubits` (as in PennyLane's `qml.probs`).
+
+        Returns a tensor of length 2**len(qubits) where index bit j is the
+        outcome of `qubits[j]` (the first listed qubit is the least-significant
+        bit, matching the SDK-wide convention). Differentiable."""
+        state = self.statevector(backend, **kwargs)
+        p = torch.abs(state) ** 2
+        if qubits is None:
+            return p
+        keep = list(qubits)
+        if len(set(keep)) != len(keep):
+            raise ValueError('qubits must not contain duplicates.')
+        n = self.n_qubits
+        if any(not 0 <= q < n for q in keep):
+            raise ValueError(f'qubits must be in range(0, {n}).')
+        # After reshape, axis k corresponds to qubit n-1-k (the statevector
+        # index has qubit 0 as its least-significant bit).
+        t = p.reshape((2, ) * n)
+        keep_set = set(keep)
+        sum_axes = [n - 1 - q for q in range(n) if q not in keep_set]
+        if sum_axes:
+            t = t.sum(dim=sum_axes)
+        remaining = [q for q in reversed(range(n)) if q in keep_set]
+        # reshape(-1) makes the first axis most significant, so order axes as
+        # [last listed qubit, ..., first listed qubit].
+        t = t.permute([remaining.index(q) for q in reversed(keep)])
+        return t.reshape(-1)
+
+    def expect(self, hamiltonian: Any, backend: 'BackendUnion' = None, **kwargs) -> torch.Tensor:
+        """Expectation value <psi|H|psi> of a Pauli-expression Hamiltonian on
+        the circuit's final state. Differentiable."""
+        if hasattr(hamiltonian, 'to_expr'):
+            hamiltonian = hamiltonian.to_expr().simplify()
+        return self.run(backend, hamiltonian=hamiltonian, **kwargs)
+
     def ancilla(self, n: int = 1, pos: Optional[int] = None, stop: Optional[int] = None,
                 reset: bool = True) -> '_AncillaContext':
         """Context manager allocating temporary ancilla qubit(s) for use inside the `with` block.

--- a/blueqat/circuit_funcs/flatten.py
+++ b/blueqat/circuit_funcs/flatten.py
@@ -68,6 +68,10 @@ def flatten(c: Circuit) -> Circuit:
                         options
                     )
                 )
+        elif isinstance(op, g.Barrier):
+            # スライス指定を明示的な量子ビット列に展開して1つのbarrierとして保持
+            ops.append(op.create(tuple(op.target_iter(n_qubits)), op.params, None))
+
         elif isinstance(op, g.Gate):
             # 3量子ビット以上のゲート (ccx/ccz/cswap 等)。これらの targets は
             # スライス不可の明示的なタプルなので、そのまま新しい回路へ移せばよい。

--- a/blueqat/cloud.py
+++ b/blueqat/cloud.py
@@ -1,0 +1,175 @@
+# Copyright 2019-2026 The Blueqat Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Groundwork for API-key based access to the Blueqat cloud service.
+
+Credential resolution order:
+1. An explicit `configure(api_key=...)` call in the current process.
+2. The `BLUEQAT_API_KEY` environment variable.
+3. The config file `~/.blueqat/config.json` (written by `save_api_key`,
+   created with owner-only permissions).
+
+The `cloud` backend registered by this module serializes a circuit to the
+JSON wire format (see `blueqat.circuit_funcs.json_serializer`) and hands it
+to a transport. Until the public endpoint is live, the default transport
+raises a clear error; tests and early integrations can inject their own
+transport with `configure(transport=...)`.
+
+Importing this module registers the backend, so after `import blueqat.cloud`
+a circuit can be submitted with `Circuit(...).run(backend='cloud')`.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from .backends.backendbase import Backend, register_backend
+from .gate import Operation
+
+DEFAULT_ENDPOINT = "https://cloudapi.blueqat.com/v2"
+ENV_API_KEY = "BLUEQAT_API_KEY"
+
+_session: Dict[str, Any] = {"api_key": None, "endpoint": None, "transport": None}
+
+
+def config_path() -> Path:
+    """Path of the persistent config file (override dir with BLUEQAT_CONFIG_DIR)."""
+    base = os.environ.get("BLUEQAT_CONFIG_DIR")
+    root = Path(base) if base else Path.home() / ".blueqat"
+    return root / "config.json"
+
+
+def _load_config_file() -> Dict[str, Any]:
+    path = config_path()
+    if not path.is_file():
+        return {}
+    try:
+        with open(path, encoding='utf-8') as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_api_key(api_key: str, endpoint: Optional[str] = None) -> Path:
+    """Persist the API key to the config file with owner-only permissions."""
+    if not api_key or not isinstance(api_key, str):
+        raise ValueError("api_key must be a non-empty string.")
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = _load_config_file()
+    data["api_key"] = api_key
+    if endpoint is not None:
+        data["endpoint"] = endpoint
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+    # API keys are secrets: restrict the file to its owner.
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    return path
+
+
+def delete_api_key() -> None:
+    """Remove the stored API key from the config file (if present)."""
+    path = config_path()
+    data = _load_config_file()
+    if "api_key" in data:
+        del data["api_key"]
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def get_api_key() -> Optional[str]:
+    """Resolve the API key: configure() > environment > config file."""
+    if _session["api_key"]:
+        return _session["api_key"]
+    env = os.environ.get(ENV_API_KEY)
+    if env:
+        return env
+    return _load_config_file().get("api_key")
+
+
+def get_endpoint() -> str:
+    """Resolve the service endpoint: configure() > config file > default."""
+    if _session["endpoint"]:
+        return _session["endpoint"]
+    return _load_config_file().get("endpoint", DEFAULT_ENDPOINT)
+
+
+def configure(api_key: Optional[str] = None, endpoint: Optional[str] = None,
+              transport: Optional[Callable[[Dict[str, Any]], Any]] = None) -> None:
+    """Set session-level cloud settings (highest priority, not persisted).
+
+    `transport` is a callable receiving the JSON-compatible request dict and
+    returning the job result; inject one for tests or early integrations."""
+    if api_key is not None:
+        _session["api_key"] = api_key
+    if endpoint is not None:
+        _session["endpoint"] = endpoint
+    if transport is not None:
+        _session["transport"] = transport
+
+
+def reset_configuration() -> None:
+    """Clear session-level settings set by `configure` (env/file are untouched)."""
+    _session["api_key"] = None
+    _session["endpoint"] = None
+    _session["transport"] = None
+
+
+def _mask(key: str) -> str:
+    return f"{key[:4]}...{key[-2:]}" if len(key) > 8 else "***"
+
+
+class CloudBackend(Backend):
+    """Backend submitting circuits to the Blueqat cloud service.
+
+    The request payload is the versioned JSON circuit schema plus run
+    parameters, so server and SDK can evolve independently."""
+
+    def run(self, gates: List[Operation], n_qubits: int, *args: Any, **kwargs: Any) -> Any:
+        api_key = get_api_key()
+        if not api_key:
+            raise RuntimeError(
+                "Blueqat cloud API key is not set. Set the BLUEQAT_API_KEY "
+                "environment variable, call blueqat.cloud.save_api_key(...), or "
+                "blueqat.cloud.configure(api_key=...).")
+
+        from .circuit import Circuit
+        from .circuit_funcs.json_serializer import serialize
+        request = {
+            "circuit": serialize(Circuit(n_qubits, list(gates))),
+            "shots": kwargs.get("shots"),
+            "returns": kwargs.get("returns"),
+            "options": {k: v for k, v in kwargs.items()
+                        if k not in ("shots", "returns")},
+        }
+
+        transport = _session["transport"]
+        if transport is None:
+            raise RuntimeError(
+                f"The Blueqat cloud service endpoint ({get_endpoint()}) is not "
+                "available yet in this SDK version. Inject a transport with "
+                "blueqat.cloud.configure(transport=...) to submit jobs.")
+        return transport(request)
+
+    def __repr__(self) -> str:
+        key = get_api_key()
+        status = f"api_key={_mask(key)}" if key else "unconfigured"
+        return f"CloudBackend({status}, endpoint={get_endpoint()!r})"
+
+
+# Importing blueqat.cloud makes the backend available as backend='cloud'.
+register_backend("cloud", CloudBackend, overwrite=True)

--- a/blueqat/gate.py
+++ b/blueqat/gate.py
@@ -990,6 +990,83 @@ class ZZDagGate(TwoQubitGate):
         return torch.diag(torch.tensor([1, -1j, -1j, 1], dtype=torch.complex128))
 
 
+class ISwapGate(TwoQubitGate, IFallbackOperation):
+    """iSWAP gate: swaps two qubits and phases the swapped amplitudes by i."""
+    lowername = "iswap"
+
+    @classmethod
+    def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'ISwapGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
+        return cls(targets)
+
+    def dagger(self):
+        return ISwapDagGate(self.targets)
+
+    def fallback(self, n_qubits):
+        return self._make_fallback_for_control_target_iter(
+            n_qubits,
+            lambda c, t: [SGate(c), SGate(t), HGate(c),
+                          CXGate((c, t)), CXGate((t, c)), HGate(t)])
+
+    def matrix(self):
+        # Symmetric in its two qubits, so the control/target bit convention
+        # doesn't matter: |01> <-> i|10>.
+        return torch.tensor([
+            [1, 0, 0, 0],
+            [0, 0, 1j, 0],
+            [0, 1j, 0, 0],
+            [0, 0, 0, 1]
+        ], dtype=torch.complex128)
+
+
+class ISwapDagGate(TwoQubitGate, IFallbackOperation):
+    """Dagger of iSWAP gate."""
+    lowername = "iswapdg"
+
+    @classmethod
+    def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'ISwapDagGate':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
+        return cls(targets)
+
+    def dagger(self):
+        return ISwapGate(self.targets)
+
+    def fallback(self, n_qubits):
+        return self._make_fallback_for_control_target_iter(
+            n_qubits,
+            lambda c, t: [HGate(t), CXGate((t, c)), CXGate((c, t)),
+                          HGate(c), SDagGate(t), SDagGate(c)])
+
+    def matrix(self):
+        return torch.tensor([
+            [1, 0, 0, 0],
+            [0, 0, -1j, 0],
+            [0, -1j, 0, 0],
+            [0, 0, 0, 1]
+        ], dtype=torch.complex128)
+
+
+class Barrier(IFallbackOperation):
+    """Barrier: a no-op marker separating circuit sections (as in Qiskit and
+    OpenQASM). Simulation backends treat it as the identity via its empty
+    fallback; the QASM output backend emits a real `barrier` statement."""
+    lowername = "barrier"
+
+    @classmethod
+    def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'Barrier':
+        if params or options:
+            raise ValueError(f"{cls.__name__} doesn't take parameters")
+        return cls(targets)
+
+    def fallback(self, _):
+        return []
+
+    def dagger(self):
+        return self
+
+
 class Measurement(Operation):
     """Measurement operation"""
     lowername = "measure"

--- a/blueqat/gateset.py
+++ b/blueqat/gateset.py
@@ -60,13 +60,16 @@ GATE_SET: Dict[str, Type[gate.Operation]] = {
     "cz": gate.CZGate,
     "toffoli": gate.ToffoliGate,
     # Other multi qubit gates (alphabetical)
+    "iswap": gate.ISwapGate,
+    "iswapdg": gate.ISwapDagGate,
     "rxx": gate.RXXGate,
     "ryy": gate.RYYGate,
     "rzz": gate.RZZGate,
     "swap": gate.SwapGate,
     "zz": gate.ZZGate,
     "zzdg": gate.ZZDagGate,
-    # Measure and reset (alphabetical)
+    # Measure, reset and barrier (alphabetical)
+    "barrier": gate.Barrier,
     "m": gate.Measurement,
     "measure": gate.Measurement,
     "reset": gate.Reset,

--- a/blueqat/utils.py
+++ b/blueqat/utils.py
@@ -782,8 +782,13 @@ def get_measurement_sampler(n_sample: int, device: Optional[torch.device] = None
         meas_tuple = tuple(meas)
         statevector = circuit.run()
         probs = torch.abs(statevector) ** 2
-        
-        samples = torch.multinomial(probs, n_sample, replacement=True)
+
+        # torch.multinomial is capped at 2^24 categories; inverse-CDF sampling
+        # (cumsum + searchsorted) has no such limit. Same approach as TorchBackend.
+        cdf = torch.cumsum(probs, dim=0)
+        cdf[-1] = 1.0
+        u = torch.rand(n_sample, device=probs.device, dtype=probs.dtype)
+        samples = torch.searchsorted(cdf, u)
         unique_elements, counts = torch.unique(samples, return_counts=True)
         
         result_counts = Counter()

--- a/tests/test_circuit_info.py
+++ b/tests/test_circuit_info.py
@@ -1,0 +1,178 @@
+"""Tests for circuit introspection & convenience APIs added for parity with
+other quantum SDKs: depth(), count_ops(), probs(), expect(), plus the iswap
+gate and barrier operation."""
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from blueqat import Circuit
+from blueqat.circuit_funcs.circuit_to_unitary import circuit_to_unitary
+from blueqat.utils import X, Z
+
+
+# --- depth / count_ops --------------------------------------------------------
+
+def test_depth_empty():
+    assert Circuit(3).depth() == 0
+
+
+def test_depth_parallel_gates_count_once():
+    # h on all 3 qubits is depth 1, not 3.
+    assert Circuit(3).h[:].depth() == 1
+
+
+def test_depth_sequential_chain():
+    c = Circuit(3).h[:].cx[0, 1].cx[1, 2].m[:]
+    # h(1) -> cx01(2) -> cx12(3) -> m(4)
+    assert c.depth() == 4
+
+
+def test_depth_independent_qubits():
+    c = Circuit(2).h[0].h[0].h[0].x[1]
+    assert c.depth() == 3
+
+
+def test_barrier_does_not_add_depth():
+    assert Circuit(2).h[:].barrier[:].x[:].depth() == 2
+
+
+def test_count_ops_expands_slices():
+    c = Circuit(3).h[:].cx[0, 1].cx[1, 2].barrier[:].m[:]
+    counts = c.count_ops()
+    assert counts == {'h': 3, 'cx': 2, 'barrier': 1, 'measure': 3}
+
+
+def test_count_ops_three_qubit_gate():
+    assert Circuit(3).ccx[0, 1, 2].count_ops() == {'ccx': 1}
+
+
+# --- probs --------------------------------------------------------------------
+
+def test_probs_full():
+    p = Circuit(2).h[0].cx[0, 1].probs()
+    assert torch.allclose(p, torch.tensor([0.5, 0.0, 0.0, 0.5], dtype=p.dtype), atol=1e-8)
+
+
+def test_probs_marginal_single_qubit():
+    # qubit 0 in |1>, qubit 1 in |+>: marginal of qubit 1 is 50/50.
+    c = Circuit(2).x[0].h[1]
+    assert torch.allclose(c.probs([0]), torch.tensor([0.0, 1.0], dtype=torch.float64), atol=1e-8)
+    assert torch.allclose(c.probs([1]), torch.tensor([0.5, 0.5], dtype=torch.float64), atol=1e-8)
+
+
+def test_probs_qubit_order():
+    # State |q1 q0> = |01>: probs([0, 1]) indexes bit0=q0, bit1=q1 -> P(index 1)=1;
+    # probs([1, 0]) swaps the roles -> P(index 2)=1.
+    c = Circuit(2).x[0]
+    p01 = c.probs([0, 1])
+    p10 = c.probs([1, 0])
+    assert p01[1].item() == pytest.approx(1.0)
+    assert p10[2].item() == pytest.approx(1.0)
+
+
+def test_probs_sum_to_one_on_marginal():
+    c = Circuit(3).h[:].cx[0, 1].crz(0.3)[1, 2]
+    for qubits in ([0], [1, 2], [2, 0], None):
+        p = c.probs(qubits)
+        assert p.sum().item() == pytest.approx(1.0, abs=1e-8)
+
+
+def test_probs_rejects_bad_qubits():
+    with pytest.raises(ValueError):
+        Circuit(2).h[0].probs([0, 0])
+    with pytest.raises(ValueError):
+        Circuit(2).h[0].probs([2])
+
+
+def test_probs_is_differentiable():
+    theta = torch.tensor(0.4, dtype=torch.float64, requires_grad=True)
+    p = Circuit(1).rx(theta)[0].probs([0])
+    p[1].backward()
+    # P(1) = sin^2(theta/2), dP/dtheta = sin(theta)/2
+    assert theta.grad.item() == pytest.approx(math.sin(0.4) / 2, abs=1e-8)
+
+
+# --- expect ---------------------------------------------------------------------
+
+def test_expect_z_observable():
+    theta = torch.tensor(0.4, dtype=torch.float64, requires_grad=True)
+    e = Circuit(1).rx(theta)[0].expect(1.0 * Z[0])
+    assert e.item() == pytest.approx(math.cos(0.4), abs=1e-7)
+    e.backward()
+    assert theta.grad.item() == pytest.approx(-math.sin(0.4), abs=1e-7)
+
+
+def test_expect_multi_term_hamiltonian():
+    # H = 0.5*Z0 + 2.0*X1 on |0>|+> gives 0.5 + 2.0 = 2.5.
+    c = Circuit(2).h[1]
+    e = c.expect(0.5 * Z[0] + 2.0 * X[1])
+    assert e.item() == pytest.approx(2.5, abs=1e-7)
+
+
+def test_expect_accepts_bare_pauli():
+    e = Circuit(1).expect(Z[0])
+    assert e.item() == pytest.approx(1.0, abs=1e-8)
+
+
+# --- iswap / barrier -------------------------------------------------------------
+
+ISWAP_MATRIX = np.array([
+    [1, 0, 0, 0],
+    [0, 0, 1j, 0],
+    [0, 1j, 0, 0],
+    [0, 0, 0, 1],
+])
+
+
+def test_iswap_matrix():
+    assert np.allclose(circuit_to_unitary(Circuit(2).iswap[0, 1]), ISWAP_MATRIX, atol=1e-8)
+
+
+def test_iswap_fallback_matches_matrix():
+    # The statevector backend runs iswap natively from matrix(); running the
+    # fallback decomposition explicitly must give the same unitary.
+    from blueqat.gate import ISwapGate
+    fb = Circuit(2, ISwapGate((0, 1)).fallback(2))
+    assert np.allclose(circuit_to_unitary(fb), ISWAP_MATRIX, atol=1e-8)
+
+
+def test_iswap_dagger_roundtrip():
+    u = circuit_to_unitary(Circuit(2).iswap[0, 1].iswapdg[0, 1])
+    assert np.allclose(u, np.eye(4), atol=1e-8)
+
+
+def test_iswap_backends_agree():
+    sv = Circuit(2).h[0].iswap[0, 1].run(backend='statevector')
+    tn = Circuit(2).h[0].iswap[0, 1].run(backend='tensornet')
+    assert torch.allclose(sv, tn, atol=1e-8)
+
+
+def test_barrier_is_identity_in_simulation():
+    with_b = Circuit(2).h[0].barrier[:].cx[0, 1].run()
+    without = Circuit(2).h[0].cx[0, 1].run()
+    assert torch.allclose(with_b, without, atol=1e-12)
+
+
+def test_barrier_in_qasm_output():
+    qasm = Circuit(3).h[0].barrier[:].to_qasm()
+    assert "barrier q[0],q[1],q[2];" in qasm
+
+
+def test_barrier_dagger_and_flatten():
+    from blueqat.circuit_funcs.flatten import flatten
+    c = Circuit(2).h[0].barrier[:].x[1]
+    d = c.dagger()
+    assert [op.lowername for op in d.ops] == ['x', 'barrier', 'h']
+    f = flatten(c)
+    assert [op.lowername for op in f.ops] == ['h', 'barrier', 'x']
+    assert f.ops[1].targets == (0, 1)
+
+
+def test_barrier_json_roundtrip():
+    from blueqat.circuit_funcs.json_serializer import serialize, deserialize
+    c = Circuit(2).h[0].barrier[:].cx[0, 1]
+    c2 = deserialize(serialize(c))
+    assert [op.lowername for op in c2.ops] == ['h', 'barrier', 'cx']
+    assert torch.allclose(c.run(), c2.run(), atol=1e-12)

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,0 +1,120 @@
+"""Tests for the API-key based cloud-access groundwork (blueqat.cloud).
+
+No network access happens anywhere here: the transport is injectable, and the
+default transport refuses to run until the public endpoint ships.
+"""
+import json
+import os
+import stat
+
+import pytest
+
+import blueqat.cloud as cloud
+from blueqat import Circuit
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Point the config file at a temp dir and clear env/session state."""
+    monkeypatch.setenv("BLUEQAT_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv(cloud.ENV_API_KEY, raising=False)
+    cloud.reset_configuration()
+    yield
+    cloud.reset_configuration()
+
+
+# --- credential resolution -------------------------------------------------------
+
+def test_no_key_by_default():
+    assert cloud.get_api_key() is None
+
+
+def test_env_var_key(monkeypatch):
+    monkeypatch.setenv(cloud.ENV_API_KEY, "env-key-123")
+    assert cloud.get_api_key() == "env-key-123"
+
+
+def test_save_and_load_key_file():
+    path = cloud.save_api_key("file-key-456")
+    assert cloud.get_api_key() == "file-key-456"
+    data = json.loads(path.read_text())
+    assert data["api_key"] == "file-key-456"
+
+
+def test_config_file_permissions_owner_only():
+    path = cloud.save_api_key("secret-key")
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == (stat.S_IRUSR | stat.S_IWUSR), f"config file mode is {oct(mode)}"
+
+
+def test_configure_beats_env_and_file(monkeypatch):
+    cloud.save_api_key("file-key")
+    monkeypatch.setenv(cloud.ENV_API_KEY, "env-key")
+    cloud.configure(api_key="session-key")
+    assert cloud.get_api_key() == "session-key"
+
+
+def test_env_beats_file(monkeypatch):
+    cloud.save_api_key("file-key")
+    monkeypatch.setenv(cloud.ENV_API_KEY, "env-key")
+    assert cloud.get_api_key() == "env-key"
+
+
+def test_delete_api_key():
+    cloud.save_api_key("to-be-deleted")
+    cloud.delete_api_key()
+    assert cloud.get_api_key() is None
+
+
+def test_endpoint_resolution():
+    assert cloud.get_endpoint() == cloud.DEFAULT_ENDPOINT
+    cloud.save_api_key("k", endpoint="https://staging.example.com")
+    assert cloud.get_endpoint() == "https://staging.example.com"
+    cloud.configure(endpoint="https://session.example.com")
+    assert cloud.get_endpoint() == "https://session.example.com"
+
+
+def test_save_rejects_empty_key():
+    with pytest.raises(ValueError):
+        cloud.save_api_key("")
+
+
+# --- backend wiring -----------------------------------------------------------------
+
+def test_cloud_backend_reachable_from_circuit_run():
+    # Importing blueqat.cloud registers the 'cloud' backend in the plugin
+    # registry, which Circuit.run consults.
+    with pytest.raises(RuntimeError, match="API key is not set"):
+        Circuit(1).h[0].run(backend="cloud")
+
+
+def test_cloud_backend_requires_transport_when_key_set():
+    cloud.configure(api_key="some-key")
+    with pytest.raises(RuntimeError, match="not.*available yet"):
+        Circuit(1).h[0].run(backend="cloud")
+
+
+def test_cloud_backend_submits_serialized_circuit():
+    captured = {}
+
+    def fake_transport(request):
+        captured.update(request)
+        return {"job_id": "job-1", "status": "queued"}
+
+    cloud.configure(api_key="some-key", transport=fake_transport)
+    result = Circuit(2).h[0].cx[0, 1].m[:].run(backend="cloud", shots=100)
+
+    assert result == {"job_id": "job-1", "status": "queued"}
+    assert captured["shots"] == 100
+    circuit_json = captured["circuit"]
+    assert circuit_json["schema"]["name"] == "blueqat-circuit"
+    assert circuit_json["n_qubits"] == 2
+    names = [op["name"] for op in circuit_json["ops"]]
+    assert names == ["h", "cx", "measure", "measure"]
+
+
+def test_cloud_backend_repr_masks_key():
+    cloud.configure(api_key="super-secret-api-key-value")
+    r = repr(cloud.CloudBackend())
+    assert "super-secret-api-key-value" not in r
+    assert "supe" in r  # masked prefix only


### PR DESCRIPTION
## Summary
2回目の全体監査での修正3件と、Qiskit/PennyLane比較での機能追加、クラウドAPIキー基盤の整備。

**監査修正:**
- `Circuit.run(backend='composer')` のクラッシュ（FlexibleCircuitComposerにrunがない）
- 描画バックエンドが `rx(torch.tensor(...))` などのtensorパラメータでクラッシュ
- `get_measurement_sampler` に残っていた torch.multinomial の2^24上限を逆CDF方式に統一

**機能追加（Qiskit/PennyLaneパリティ）:**
- `Circuit.depth()` / `Circuit.count_ops()`（スライス展開対応、barrierは深さに不算入）
- `Circuit.probs(qubits=None)` — 周辺化対応・微分可能な測定確率（qml.probs相当）
- `Circuit.expect(hamiltonian)` — 微分可能な期待値の簡便API
- iSWAP / iSWAP† ゲート（行列 + s/h/cx fallback + dagger）
- barrier（シミュレーションでは恒等、QASM出力では正式なbarrier文、dagger/flatten/JSON対応）

**クラウドAPIキー基盤（blueqat/cloud.py）:**
- キー解決: `configure()` > 環境変数 `BLUEQAT_API_KEY` > `~/.blueqat/config.json`（0600権限で保存、reprではマスク）
- `import blueqat.cloud` で `backend='cloud'` が登録され、回路をバージョン付きJSONスキーマで送信。エンドポイント公開までは transport 注入方式（テスト用）、未設定時は明確なエラー

## Test plan
- [x] `pytest tests/ -q` 全1540件通過（+37件）
- [x] examples/ 全7本の実行確認
- [x] READMEの新規スニペットの実行確認