### PR TITLE
fix(packaging): include blueqat.eo in installed packages (2.1.1)

### DIFF
--- a/blueqat/_version.py
+++ b/blueqat/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of blueqat."""
 
-__version__: str = "2.1.0"
+__version__: str = "2.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@ Homepage = "https://github.com/Blueqat/Blueqat"
 version = { attr = "blueqat._version.__version__" }
 
 [tool.setuptools]
-packages = ["blueqat", "blueqat.backends", "blueqat.circuit_funcs", "blueqat.macros"]
+packages = ["blueqat", "blueqat.backends", "blueqat.circuit_funcs", "blueqat.eo", "blueqat.macros"]


### PR DESCRIPTION
2.1.0のパッケージングバグ修正: pyproject.tomlのpackagesリストにblueqat.eoが漏れており、通常のpip installで ModuleNotFoundError: No module named 'blueqat.eo' が発生していました。クリーンな非editableインストールでimport・exchゲート・'eo'バックエンドの動作を検証済み。バージョン2.1.1。