### PR TITLE
feat: named gate blocks (nestable subcircuits) with tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Runnable scripts in [`examples/`](examples/):
 - `maxcut_qaoa.py` -- QAOA for the graph Max-Cut problem
 - `numpartition_qaoa.py` -- QAOA for number partitioning
 - `exchange_only.py` -- exchange-only spin qubits: logical circuits from pure exchange pulses
+- `shor_15.py` -- Shor's order finding for N=15 structured with nested named blocks
 
 ### Install
 ```
@@ -126,6 +127,21 @@ Circuit(4).x[:].run(hamiltonian=hamiltonian)
 
 # Or the equivalent convenience method (differentiable):
 Circuit(4).x[:].expect(hamiltonian)
+```
+
+### Named gate blocks (nested subcircuits)
+```python
+c = Circuit(7)
+with c.block("order-finding"):
+    with c.block("superposition"):
+        c.h[4, 5, 6]
+    with c.block("c-U^1"):
+        c.cswap[4, 2, 3].cswap[4, 1, 2].cswap[4, 0, 1]
+    c.append_block("IQFT", qft_circuit(3).dagger(), offset=4)
+
+print(c.tree())      # shows the nested structure (see examples/shor_15.py)
+c.run()              # backends see the plain gates -- execution is unchanged
+c.dagger()           # inverts blocks as blocks ("order-finding†")
 ```
 
 ### Probabilities, depth and gate counts

--- a/blueqat/backends/draw_backend.py
+++ b/blueqat/backends/draw_backend.py
@@ -449,16 +449,26 @@ class DrawCircuit(Backend):
     def run(self, gates, n_qubits, *args, **kwargs):
         """Blueqatのエントリーポイント"""
         import warnings
+        from ..gate import GateBlock
         gates, ctx = self._preprocess_run(gates, n_qubits, args, kwargs)
-        for gate in gates:
-            handler = getattr(self, f"gate_{gate.lowername}", None)
-            if handler is not None:
-                ctx = handler(gate, ctx)
-            else:
-                # 黙って省略すると「その操作が無い回路図」ができてしまうため、
-                # 描画されなかったことを必ず警告する。
-                warnings.warn(
-                    f"Gate '{gate.lowername}' is not supported by the draw "
-                    "backend and was omitted from the diagram.")
+
+        def _draw(ops, ctx):
+            for gate in ops:
+                if isinstance(gate, GateBlock):
+                    # ブロックは中身を展開して描画する (構造は tree() で見る)
+                    ctx = _draw(gate.ops, ctx)
+                    continue
+                handler = getattr(self, f"gate_{gate.lowername}", None)
+                if handler is not None:
+                    ctx = handler(gate, ctx)
+                else:
+                    # 黙って省略すると「その操作が無い回路図」ができてしまうため、
+                    # 描画されなかったことを必ず警告する。
+                    warnings.warn(
+                        f"Gate '{gate.lowername}' is not supported by the draw "
+                        "backend and was omitted from the diagram.")
+            return ctx
+
+        ctx = _draw(gates, ctx)
         self._postprocess_run(ctx)
         return ctx

--- a/blueqat/circuit.py
+++ b/blueqat/circuit.py
@@ -187,14 +187,17 @@ class Circuit:
         vec, cnt = backend.run(self.ops, self.n_qubits, shots=1, returns='statevector_and_shots', **kwargs)
         return vec, next(iter(cnt))
 
-    def _expanded_applications(self):
+    def _expanded_applications(self, ops: Optional[list] = None):
         """Yield (lowername, qubit-tuple) for each atomic gate application,
-        expanding slices/multi-targets the same way the backends do."""
-        from .gate import (Barrier, Gate, Measurement, OneQubitGate, Reset,
-                           TwoQubitGate)
+        expanding slices/multi-targets (and recursing into named blocks) the
+        same way the backends do."""
+        from .gate import (Barrier, Gate, GateBlock, Measurement, OneQubitGate,
+                           Reset, TwoQubitGate)
         n_qubits = self.n_qubits
-        for op in self.ops:
-            if isinstance(op, Barrier):
+        for op in (self.ops if ops is None else ops):
+            if isinstance(op, GateBlock):
+                yield from self._expanded_applications(op.ops)
+            elif isinstance(op, Barrier):
                 yield op.lowername, tuple(op.target_iter(n_qubits))
             elif isinstance(op, (OneQubitGate, Measurement, Reset)):
                 for t in op.target_iter(n_qubits):
@@ -263,6 +266,81 @@ class Circuit:
             hamiltonian = hamiltonian.to_expr().simplify()
         return self.run(backend, hamiltonian=hamiltonian, **kwargs)
 
+    def block(self, name: str) -> '_BlockContext':
+        """Group the operations appended inside the `with` body into a named,
+        nestable block (as in the sub-circuits of Shor's algorithm):
+
+            c = Circuit(4)
+            with c.block("QFT"):
+                c.h[0].cphase(math.pi / 2)[0, 1]
+                ...
+
+        Blocks change nothing about execution -- every backend transparently
+        sees the inner gates -- but the structure is kept in `repr()`,
+        `Circuit.tree()`, and survives `dagger()` (as a mirrored block named
+        `name + '†'`)."""
+        return _BlockContext(self, name)
+
+    def append_block(self, name: str, subcircuit: 'Circuit',
+                     offset: int = 0) -> 'Circuit':
+        """Append an existing circuit as a named block.
+
+        `offset` shifts every qubit index of `subcircuit`, so a library
+        circuit built on qubits 0..k can be placed anywhere. (Shifting
+        resolves slice targets against `subcircuit.n_qubits` first.)"""
+        from .circuit_funcs.flatten import flatten
+        from .gate import GateBlock
+        if offset < 0:
+            raise ValueError('offset must not be negative.')
+        if offset == 0:
+            ops = [op for op in subcircuit.ops]
+            width = subcircuit.n_qubits
+        else:
+            flat = flatten(subcircuit)
+            ops = []
+            for op in flat.ops:
+                targets = op.targets
+                if isinstance(targets, int):
+                    shifted: Any = targets + offset
+                else:
+                    shifted = tuple(t + offset for t in targets)
+                options = None
+                if getattr(op, 'key', None) is not None:
+                    options = {'key': op.key}
+                    if op.duplicated is not None:
+                        options['duplicated'] = op.duplicated
+                ops.append(op.create(shifted, op.params, options))
+            width = flat.n_qubits + offset
+        self.ops.append(GateBlock(name, ops))
+        self.n_qubits = max(self.n_qubits, width)
+        return self
+
+    def tree(self) -> str:
+        """A text rendering of the circuit's nested block structure:
+
+            Circuit(4)
+            ├─ h[0]
+            └─ QFT
+               ├─ cphase(1.5708)[0, 1]
+               └─ ...
+        """
+        from .gate import GateBlock
+
+        def _lines(ops, prefix: str):
+            out = []
+            for i, op in enumerate(ops):
+                last = i == len(ops) - 1
+                branch = '└─ ' if last else '├─ '
+                cont = '   ' if last else '│  '
+                if isinstance(op, GateBlock):
+                    out.append(f'{prefix}{branch}{op.name}')
+                    out.extend(_lines(op.ops, prefix + cont))
+                else:
+                    out.append(f'{prefix}{branch}{op}')
+            return out
+
+        return '\n'.join([f'Circuit({self.n_qubits})'] + _lines(self.ops, ''))
+
     def ancilla(self, n: int = 1, pos: Optional[int] = None, stop: Optional[int] = None,
                 reset: bool = True) -> '_AncillaContext':
         """Context manager allocating temporary ancilla qubit(s) for use inside the `with` block.
@@ -289,6 +367,28 @@ class Circuit:
             indices = list(range(self.n_qubits, self.n_qubits + n))
             self.n_qubits += n
         return _AncillaContext(self, indices, reset)
+
+
+class _BlockContext:
+    """Context manager returned by `Circuit.block()`. On exit, the operations
+    appended inside the body are wrapped into a single named GateBlock
+    (supports nesting: an inner block closes before its enclosing one)."""
+    def __init__(self, circuit: Circuit, name: str) -> None:
+        self.circuit = circuit
+        self.name = name
+        self._start = 0
+
+    def __enter__(self) -> '_BlockContext':
+        self._start = len(self.circuit.ops)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if exc_type is not None:
+            return
+        from .gate import GateBlock
+        inner = self.circuit.ops[self._start:]
+        del self.circuit.ops[self._start:]
+        self.circuit.ops.append(GateBlock(self.name, inner))
 
 
 class _AncillaContext:

--- a/blueqat/circuit_funcs/flatten.py
+++ b/blueqat/circuit_funcs/flatten.py
@@ -39,7 +39,13 @@ def flatten(c: Circuit) -> Circuit:
     ops: List[g.Operation] = []
     
     for op in c.ops:
-        if isinstance(op, (g.OneQubitGate, g.Reset)):
+        if isinstance(op, g.GateBlock):
+            # 名前付きブロックは中身に展開する (フラット化で構造は失われる。
+            # JSONシリアライズ等のフラットなスキーマ向け)。
+            inner = flatten(Circuit(n_qubits, list(op.ops)))
+            ops.extend(inner.ops)
+
+        elif isinstance(op, (g.OneQubitGate, g.Reset)):
             ops.extend([
                 op.create(t, op.params, None) 
                 for t in op.target_iter(n_qubits)

--- a/blueqat/eo/transpiler.py
+++ b/blueqat/eo/transpiler.py
@@ -59,9 +59,17 @@ class EOTranspiler(Backend):
 
     def run(self, gates: List[Operation], n_qubits: int, *args: Any,
             **kwargs: Any) -> Circuit:
+        from ..gate import GateBlock
         pulses: List[sequences.Pulse] = []
         for gate in gates:
             name = gate.lowername
+            if isinstance(gate, GateBlock):
+                # ブロックは中身を展開してトランスパイルする
+                sub = self.run(gate.ops, n_qubits)
+                for op in sub.ops:
+                    i, j = op.targets
+                    pulses.append(((int(i), int(j)), float(op.theta)))
+                continue
             if name in ('i', 'barrier'):
                 continue
             if name in self._FIXED:

--- a/blueqat/gate.py
+++ b/blueqat/gate.py
@@ -1114,6 +1114,62 @@ class Barrier(IFallbackOperation):
         return self
 
 
+class GateBlock(IFallbackOperation):
+    """A named group of operations, nestable to arbitrary depth.
+
+    Blocks give circuits the hierarchical structure of real algorithms
+    (Shor = init + modular exponentiation + inverse QFT, each built from
+    smaller blocks) without changing how they execute: every backend sees
+    the inner operations through `fallback()`, so simulation, QASM output
+    and transpilation are unaffected. The structure shows up in `repr()`
+    and in `Circuit.tree()`.
+
+    Build blocks with `Circuit.block(name)` (a context manager) or
+    `Circuit.append_block(name, subcircuit)`.
+    """
+    lowername = "block"
+
+    def __init__(self, name: str, ops: Optional[List['Operation']] = None):
+        super().__init__((), ())
+        self.name = str(name)
+        self.ops: List['Operation'] = list(ops) if ops is not None else []
+
+    @classmethod
+    def create(cls, targets: Targets, params: tuple, options: Optional[dict] = None) -> 'GateBlock':
+        raise ValueError(
+            "GateBlock is structural and can't be created from the gate set; "
+            "use Circuit.block(name) or Circuit.append_block(...).")
+
+    def fallback(self, _):
+        return self.ops
+
+    def dagger(self):
+        inner = []
+        for op in reversed(self.ops):
+            if not hasattr(op, 'dagger'):
+                raise ValueError(
+                    f"Cannot invert block '{self.name}': it contains a "
+                    f"non-invertible operation `{op.lowername}`.")
+            inner.append(op.dagger())
+        name = self.name[:-1] if self.name.endswith('†') else self.name + '†'
+        return GateBlock(name, inner)
+
+    def target_iter(self, n_qubits: int):
+        seen = set()
+        for op in self.ops:
+            if isinstance(op, GateBlock):
+                targets = op.target_iter(n_qubits)
+            else:
+                targets = op.target_iter(n_qubits)
+            for t in targets:
+                if t not in seen:
+                    seen.add(t)
+                    yield t
+
+    def __str__(self) -> str:
+        return f"block({self.name!r}, <{len(self.ops)} ops>)"
+
+
 class Measurement(Operation):
     """Measurement operation"""
     lowername = "measure"

--- a/doc/source/guide/circuits.rst
+++ b/doc/source/guide/circuits.rst
@@ -108,6 +108,43 @@ Drawing
 gate is drawable; unknown (user-registered) gates are omitted with a
 ``UserWarning``.
 
+Named gate blocks
+-----------------
+
+Real algorithms are nests of subroutines -- Shor's order finding is
+initialization, controlled modular multiplications and an inverse QFT, each
+built from smaller pieces. Named blocks keep that structure in the circuit
+object without changing execution (every backend transparently sees the
+inner gates):
+
+.. code-block:: python
+
+   c = Circuit(7)
+   with c.block("order-finding"):
+       with c.block("superposition"):
+           c.h[4, 5, 6]
+       with c.block("c-U^1"):
+           c.cswap[4, 2, 3].cswap[4, 1, 2].cswap[4, 0, 1]
+       # place a library circuit as a block, shifted to qubits 4..6
+       c.append_block("IQFT", qft_circuit(3).dagger(), offset=4)
+
+   print(c.tree())
+   # Circuit(7)
+   # └─ order-finding
+   #    ├─ superposition
+   #    │  └─ h[4, 5, 6]
+   #    ├─ c-U^1
+   #    │  └─ ...
+   #    └─ IQFT
+   #       └─ ...
+
+Blocks nest arbitrarily, show up in ``repr()`` and :meth:`~blueqat.circuit.Circuit.tree`,
+and survive :meth:`~blueqat.circuit.Circuit.dagger` as mirrored blocks
+(``"order-finding†"``). ``depth()`` / ``count_ops()`` count the contained
+gates; ``flatten()`` / JSON serialization expand blocks into plain gates
+(the flat wire format keeps no hierarchy). See ``examples/shor_15.py`` for a
+complete Shor-at-15 program written this way.
+
 Ancilla qubits
 --------------
 

--- a/doc/source/ja/guide/circuits.rst
+++ b/doc/source/ja/guide/circuits.rst
@@ -107,6 +107,42 @@ JSONシリアライズ
 全ゲートが描画可能で、未知の（ユーザー登録）ゲートは ``UserWarning`` 付き
 で省略されます。
 
+名前付きゲートブロック
+----------------------
+
+実際のアルゴリズムはサブルーチンの入れ子です — Shorの位数発見は
+「初期化・制御剰余乗算・逆QFT」で構成され、それぞれがさらに小さな部品から
+できています。名前付きブロックはその構造を回路オブジェクトに保持したまま、
+実行には一切影響しません（各バックエンドは内部のゲートを透過的に見ます）:
+
+.. code-block:: python
+
+   c = Circuit(7)
+   with c.block("order-finding"):
+       with c.block("superposition"):
+           c.h[4, 5, 6]
+       with c.block("c-U^1"):
+           c.cswap[4, 2, 3].cswap[4, 1, 2].cswap[4, 0, 1]
+       # ライブラリ回路をブロックとして配置 (量子ビット4..6へシフト)
+       c.append_block("IQFT", qft_circuit(3).dagger(), offset=4)
+
+   print(c.tree())
+   # Circuit(7)
+   # └─ order-finding
+   #    ├─ superposition
+   #    │  └─ h[4, 5, 6]
+   #    ├─ c-U^1
+   #    │  └─ ...
+   #    └─ IQFT
+   #       └─ ...
+
+ブロックは任意に入れ子でき、 ``repr()`` と :meth:`~blueqat.circuit.Circuit.tree`
+に現れ、 :meth:`~blueqat.circuit.Circuit.dagger` では鏡像ブロック
+（ ``"order-finding†"`` ）として保存されます。 ``depth()`` / ``count_ops()``
+は中身のゲートを数え、 ``flatten()`` / JSONシリアライズはブロックを
+プレーンなゲート列に展開します（フラットなワイヤ形式には階層は残りません）。
+完全なプログラム例は ``examples/shor_15.py`` を参照してください。
+
 アンシラ量子ビット
 ------------------
 

--- a/examples/shor_15.py
+++ b/examples/shor_15.py
@@ -1,0 +1,97 @@
+"""Shor's algorithm (order finding for N = 15, a = 2) built from named blocks.
+
+Shor's algorithm is naturally a nest of subroutines:
+
+    order-finding
+    ├─ superposition        (H on the counting register)
+    ├─ c-U^(2^k)            (controlled modular multiplications)
+    └─ IQFT                 (inverse QFT reads out the phase)
+
+Named blocks (`with c.block(...)`) keep exactly that structure in the circuit
+object -- `print(c.tree())` shows the nesting -- while every backend still
+executes the underlying gates transparently.
+
+Here U|x> = |2x mod 15>, which on 4 bits is just a cyclic left-shift of the
+bit register, so the controlled versions are short cswap chains. The measured
+phase s/r with r = 4 gives the factors gcd(2^(r/2) +- 1, 15) = 3 and 5.
+"""
+import math
+from math import gcd
+
+import torch
+
+from blueqat import Circuit
+
+N = 15
+A = 2
+N_WORK = 4          # work register: qubits 0..3, holds x
+N_COUNT = 3         # counting register: qubits 4..6
+COUNT = list(range(N_WORK, N_WORK + N_COUNT))
+
+
+def qft_circuit(n: int) -> Circuit:
+    """QFT on qubits 0..n-1 (kept as a library circuit; placed via append_block)."""
+    c = Circuit(n)
+    for i in reversed(range(n)):
+        c.h[i]
+        for k in range(i):
+            c.cphase(math.pi / 2 ** (i - k))[k, i]
+    for i in range(n // 2):
+        c.swap[i, n - 1 - i]
+    return c
+
+
+def build_order_finding() -> Circuit:
+    c = Circuit(N_WORK + N_COUNT)
+
+    with c.block("order-finding(a=2, N=15)"):
+        with c.block("init |x=1>"):
+            c.x[0]
+
+        with c.block("superposition"):
+            c.h[COUNT[0], COUNT[1], COUNT[2]]
+
+        # U: |x> -> |2x mod 15> is a cyclic left-shift of 4 bits.
+        # U^(2^k) shifts by 2^k; U^4 = identity, so only k = 0, 1 matter.
+        with c.block("c-U^1"):
+            ctl = COUNT[0]
+            c.cswap[ctl, 2, 3].cswap[ctl, 1, 2].cswap[ctl, 0, 1]
+
+        with c.block("c-U^2"):
+            ctl = COUNT[1]
+            c.cswap[ctl, 0, 2].cswap[ctl, 1, 3]
+
+        # IQFT on the counting register: reuse the QFT library circuit,
+        # invert it with dagger(), and place it at offset 4.
+        c.append_block("IQFT", qft_circuit(N_COUNT).dagger(), offset=N_WORK)
+
+    return c
+
+
+if __name__ == "__main__":
+    print("Shor's order finding for N = 15, a = 2, with named blocks")
+    print("=" * 60)
+
+    c = build_order_finding()
+    print(c.tree())
+    print()
+
+    # Read out the counting register's probabilities (differentiable API,
+    # but here just used for exact classical post-processing).
+    probs = c.probs(COUNT)
+    peaks = {k: p.item() for k, p in enumerate(probs) if p.item() > 1e-9}
+    print("Counting-register outcomes (value: probability):")
+    for k, p in sorted(peaks.items()):
+        print(f"  {k:3d} (phase {k}/8): {p:.4f}")
+
+    # Phase peaks sit at multiples of 1/r with r = 4: 0, 2, 4, 6 out of 8.
+    assert set(peaks) == {0, 2, 4, 6}, peaks
+    assert all(abs(p - 0.25) < 1e-9 for p in peaks.values())
+
+    # Recover the order r from the non-trivial phase 1/4, then the factors.
+    r = 4
+    assert pow(A, r, N) == 1
+    f1, f2 = gcd(A ** (r // 2) - 1, N), gcd(A ** (r // 2) + 1, N)
+    print(f"\nOrder r = {r};  gcd(a^(r/2) -+ 1, N) = {f1}, {f2}")
+    assert {f1, f2} == {3, 5}
+    print(f"Factors of {N}: {f1} x {f2}  -- OK")

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,203 @@
+"""Tests for named gate blocks (nested subcircuits): construction, execution
+transparency across backends, structure views, dagger, and interop."""
+import math
+
+import pytest
+import torch
+
+from blueqat import Circuit
+from blueqat.gate import GateBlock
+
+ATOL = 1e-10
+
+
+def _bell_with_block():
+    c = Circuit(2)
+    with c.block("Bell"):
+        c.h[0].cx[0, 1]
+    return c
+
+
+# --- construction -------------------------------------------------------------
+
+def test_block_context_manager_groups_ops():
+    c = _bell_with_block()
+    assert len(c.ops) == 1
+    assert isinstance(c.ops[0], GateBlock)
+    assert c.ops[0].name == "Bell"
+    assert [op.lowername for op in c.ops[0].ops] == ['h', 'cx']
+
+
+def test_block_nesting():
+    c = Circuit(3)
+    with c.block("outer"):
+        c.x[0]
+        with c.block("inner"):
+            c.y[1]
+        c.z[2]
+    outer = c.ops[0]
+    assert [type(op).__name__ for op in outer.ops] == ['XGate', 'GateBlock', 'ZGate']
+    assert outer.ops[1].name == "inner"
+
+
+def test_block_grows_circuit_width():
+    c = Circuit()
+    with c.block("wide"):
+        c.h[5]
+    assert c.n_qubits == 6
+
+
+def test_block_exception_leaves_ops_ungrouped():
+    c = Circuit(1)
+    with pytest.raises(RuntimeError):
+        with c.block("broken"):
+            c.h[0]
+            raise RuntimeError("boom")
+    # on error the ops stay as-is (no half-built block is created)
+    assert [op.lowername for op in c.ops] == ['h']
+
+
+def test_append_block():
+    sub = Circuit(2).h[0].cx[0, 1]
+    c = Circuit(2).x[0]
+    c.append_block("Bell", sub)
+    assert isinstance(c.ops[1], GateBlock)
+    inline = Circuit(2).x[0].h[0].cx[0, 1]
+    assert torch.allclose(c.run(), inline.run(), atol=ATOL)
+
+
+def test_append_block_with_offset():
+    sub = Circuit(2).h[0].cx[0, 1]      # built on qubits 0, 1
+    c = Circuit()
+    c.append_block("Bell@2", sub, offset=2)
+    assert c.n_qubits == 4
+    inline = Circuit(4).h[2].cx[2, 3]
+    assert torch.allclose(c.run(), inline.run(), atol=ATOL)
+
+
+def test_append_block_offset_resolves_slices():
+    sub = Circuit(2).h[:]               # slice target
+    c = Circuit()
+    c.append_block("Hs", sub, offset=1)
+    inline = Circuit(3).h[1].h[2]
+    assert torch.allclose(c.run(), inline.run(), atol=ATOL)
+
+
+def test_append_block_rejects_negative_offset():
+    with pytest.raises(ValueError):
+        Circuit().append_block("x", Circuit(1).x[0], offset=-1)
+
+
+# --- execution transparency ----------------------------------------------------
+
+def test_block_execution_matches_inline_both_modes():
+    c = Circuit(3)
+    with c.block("algo"):
+        c.h[:]
+        with c.block("QFT"):
+            c.h[0].cphase(math.pi / 2)[0, 1].h[1]
+        c.cx[1, 2]
+    inline = Circuit(3).h[:].h[0].cphase(math.pi / 2)[0, 1].h[1].cx[1, 2]
+    for mode in ['statevector', 'tensornet']:
+        assert torch.allclose(c.run(backend=mode), inline.run(backend=mode), atol=ATOL)
+
+
+def test_block_shots():
+    c = _bell_with_block()
+    counts = c.m[:].shots(100)
+    assert set(counts) <= {"00", "11"}
+
+
+def test_block_to_qasm_expands():
+    q1 = _bell_with_block().to_qasm()
+    q2 = Circuit(2).h[0].cx[0, 1].to_qasm()
+    assert q1 == q2
+
+
+def test_block_json_serialization_via_flatten():
+    from blueqat.circuit_funcs.json_serializer import deserialize, serialize
+    c = _bell_with_block()
+    c2 = deserialize(serialize(c))
+    assert torch.allclose(c.run(), c2.run(), atol=ATOL)
+
+
+def test_block_draw_no_warning():
+    import warnings
+
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        _bell_with_block().run(backend='draw')
+    plt.close('all')
+    assert not [w for w in caught if 'omitted' in str(w.message)]
+
+
+def test_block_eo_transpile():
+    import blueqat.eo  # noqa: F401
+    c = Circuit(2)
+    with c.block("Bell"):
+        c.h[0].cx[0, 1]
+    phys = c.run(backend='eo')
+    phys_inline = Circuit(2).h[0].cx[0, 1].run(backend='eo')
+    assert [(op.targets, float(op.theta)) for op in phys.ops] == \
+           [(op.targets, float(op.theta)) for op in phys_inline.ops]
+
+
+# --- structure views -----------------------------------------------------------
+
+def test_tree_shows_nesting():
+    c = Circuit(3)
+    with c.block("outer"):
+        c.h[0]
+        with c.block("inner"):
+            c.x[1]
+    t = c.tree()
+    assert "outer" in t and "inner" in t
+    # inner is indented deeper than outer
+    outer_line = next(l for l in t.splitlines() if l.endswith("outer"))
+    inner_line = next(l for l in t.splitlines() if l.endswith("inner"))
+    assert len(inner_line) - len(inner_line.lstrip('│ ├└─')) >= 0
+    assert t.splitlines().index(inner_line) > t.splitlines().index(outer_line)
+
+
+def test_repr_shows_block():
+    c = _bell_with_block()
+    assert "block('Bell', <2 ops>)" in repr(c)
+
+
+def test_depth_and_count_ops_recurse_into_blocks():
+    c = Circuit(2)
+    with c.block("Bell"):
+        c.h[0].cx[0, 1]
+    assert c.depth() == 2
+    assert c.count_ops() == {'h': 1, 'cx': 1}
+
+
+# --- dagger ---------------------------------------------------------------------
+
+def test_block_dagger_uncomputes():
+    c = Circuit(3)
+    with c.block("algo"):
+        c.h[0].crz(0.7)[0, 1].t[2].cx[1, 2]
+    d = c.dagger()
+    assert isinstance(d.ops[0], GateBlock)
+    assert d.ops[0].name == "algo†"
+    e0 = torch.zeros(8, dtype=torch.complex128)
+    e0[0] = 1
+    assert torch.allclose((c + d).run(), e0, atol=1e-8)
+
+
+def test_block_double_dagger_name_roundtrip():
+    c = _bell_with_block()
+    dd = c.dagger().dagger()
+    assert dd.ops[0].name == "Bell"
+
+
+def test_block_dagger_rejects_measurement_inside():
+    c = Circuit(1)
+    with c.block("meas"):
+        c.h[0].m[0]
+    with pytest.raises(ValueError, match='meas'):
+        c.dagger()


### PR DESCRIPTION
## Summary
複数の量子ゲートをまとめて名前を付けられる「名前付きゲートブロック」を追加。Shorのようにサブルーチンが入れ子になったアルゴリズムの構造を、実行に影響を与えずに回路表現へ保持します。

```python
c = Circuit(7)
with c.block("order-finding"):
    with c.block("superposition"):
        c.h[4, 5, 6]
    with c.block("c-U^1"):
        c.cswap[4, 2, 3].cswap[4, 1, 2].cswap[4, 0, 1]
    c.append_block("IQFT", qft_circuit(3).dagger(), offset=4)
print(c.tree())   # 入れ子構造をツリー表示
```

- **GateBlock**: 名前付きコンテナ操作。バックエンドは既存のfallback機構で中身を透過的に実行（両シミュレーションモード・QASM出力・描画・EOトランスパイラすべて無変更で動作）
- **`Circuit.block(name)`**: withブロック内のopをグループ化するコンテキストマネージャ。任意に入れ子可。例外時はグループ化しない
- **`Circuit.append_block(name, subcircuit, offset=0)`**: ライブラリ回路をブロックとして配置（スライス解決付きの量子ビットシフト対応。QFTを0..2で作って4..6に配置、daggerでIQFT化など）
- **`Circuit.tree()`**: 入れ子構造のテキストツリー表示。`repr()`にも`block('name', <k ops>)`として表示
- **`dagger()`**: ブロックを鏡像ブロック（`name†`）として反転、二重反転で名前復元
- `depth()`/`count_ops()`は中身を集計、`flatten()`/JSONはプレーン展開

**examples/shor_15.py**: N=15のShor位数発見（a=2、Uはcswapによる巡回ビットシフト）を全編ブロック構造で記述。tree()でアルゴリズムの形が見え、位相ピークから因数3×5を復元。ドキュメント（日英）とREADMEも更新。

## Test plan
- [x] 新規テスト20件を含む全1615件通過
- [x] 全9examples実行確認（shor_15.py含む）
- [x] Sphinxドキュメントビルド成功